### PR TITLE
Fix `errcheck` lint failure and ensure response body is always closed

### DIFF
--- a/fleetdm/utils.go
+++ b/fleetdm/utils.go
@@ -178,10 +178,14 @@ func (c *FleetDMClient) Get(ctx context.Context, endpoint string, queryParams ur
 		plugin.Logger(ctx).Error("FleetDMClient.Get", "http_do_error", err, "url", fullURL.String())
 		return resp, fmt.Errorf("error performing HTTP request to %s: %w", fullURL.String(), err)
 	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			plugin.Logger(ctx).Error("FleetDMClient.Get", "close_error", cerr, "url", fullURL.String())
+		}
+	}()
 
 	// Check for non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		defer resp.Body.Close()
 		bodyBytes, readErr := io.ReadAll(resp.Body)
 		if readErr != nil {
 			plugin.Logger(ctx).Error("FleetDMClient.Get", "read_error_body_failed", readErr, "url", fullURL.String(), "status_code", resp.StatusCode)


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
$ golangci-lint run --timeout 20m ./...
0 issues.

$ go build ./...
$ go vet ./...
(no output)
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
N/A — change is internal to the FleetDM HTTP client and does not affect
any table schemas, columns, or query results.
```
</details>