### PR TITLE
Refactor HTTP client and pagination, add retry/ignore config and unit tests

### DIFF
--- a/config/fleetdm.spc
+++ b/config/fleetdm.spc
@@ -15,4 +15,7 @@ connection "fleetdm" {
   # in query results. Leave unset/false unless you understand that secrets
   # will then land in Steampipe query caches, exports, and dashboards.
   # expose_secrets = false
+
+  # Per-request timeout in seconds. Default: 30.
+  # request_timeout = 30
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,12 +75,16 @@ connection "fleetdm" {
   # Optional: opt in to returning live secret material (e.g. team enrollment
   # secrets) in query results. Default: false.
   # expose_secrets = false
+
+  # Optional: per-request timeout in seconds. Default: 30.
+  # request_timeout = 30
 }
 ```
 
 - `server_url` - Your FleetDM server URL. Must use `https` (`http` is only allowed for localhost). The plugin will attempt to append `/api/v1/` if it's not present.
 - `api_token` - Your FleetDM API token, which can be generated from your FleetDM instance (User Menu -> My account -> Get API token)
 - `expose_secrets` - Optional, default `false`. When `true`, columns containing live secret material (e.g. `fleetdm_team.secrets`, which holds agent enrollment secrets) are populated. Leave unset unless you need it: exposed secrets will land in Steampipe query caches, exports, and dashboards.
+- `request_timeout` - Optional, default `30`. Per-request timeout in seconds for FleetDM API calls.
 
 ### Credentials via environment variables
 

--- a/fleetdm/client_test.go
+++ b/fleetdm/client_test.go
@@ -1,0 +1,209 @@
+package fleetdm
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newTestClient builds a FleetDMClient pointed at the given test server.
+func newTestClient(srv *httptest.Server) *FleetDMClient {
+	return &FleetDMClient{
+		BaseURL:    srv.URL + "/api/v1/fleet/",
+		APIToken:   "test-token",
+		HTTPClient: srv.Client(),
+	}
+}
+
+func TestGetSendsExpectedHeaders(t *testing.T) {
+	t.Parallel()
+
+	var gotAuth, gotAccept, gotUA string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotAccept = r.Header.Get("Accept")
+		gotUA = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	if err := c.Get(testCtx(t), "hosts", nil, nil); err != nil {
+		t.Fatalf("Get unexpected error: %v", err)
+	}
+
+	if want := "Bearer test-token"; gotAuth != want {
+		t.Errorf("Authorization = %q, want %q", gotAuth, want)
+	}
+	if want := "application/json"; gotAccept != want {
+		t.Errorf("Accept = %q, want %q", gotAccept, want)
+	}
+	if want := "steampipe-plugin-fleetdm/" + pluginVersion; gotUA != want {
+		t.Errorf("User-Agent = %q, want %q", gotUA, want)
+	}
+}
+
+func TestGetDecodesJSONResponse(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"id": 1, "hostname": "host-A"}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	var target struct {
+		ID       int    `json:"id"`
+		Hostname string `json:"hostname"`
+	}
+	c := newTestClient(srv)
+	if err := c.Get(testCtx(t), "hosts/1", url.Values{"page": []string{"0"}}, &target); err != nil {
+		t.Fatalf("Get unexpected error: %v", err)
+	}
+	if target.ID != 1 || target.Hostname != "host-A" {
+		t.Errorf("decoded target = %+v, want ID=1 Hostname=host-A", target)
+	}
+}
+
+// Regression test: a short non-JSON 200 body used to panic via bodyBytes[:500]
+// when the body was shorter than the snippet length. It must return a decode
+// error instead.
+func TestGetShortNonJSONBodyReturnsError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		if _, err := w.Write([]byte("<html>not json 25b</html>")); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	var target map[string]interface{}
+	c := newTestClient(srv)
+	err := c.Get(testCtx(t), "hosts", nil, &target)
+	if err == nil {
+		t.Fatal("Get with non-JSON body = nil error, want decode error")
+	}
+	if !strings.Contains(err.Error(), "error decoding JSON response") {
+		t.Errorf("error = %q, want a JSON decode error", err)
+	}
+}
+
+func TestGet404ReturnsFleetAPIErrorWithTruncatedSnippet(t *testing.T) {
+	t.Parallel()
+
+	longBody := strings.Repeat("a", 300) + "TAIL-MARKER"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		if _, err := w.Write([]byte(longBody)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	err := c.Get(testCtx(t), "hosts/999", nil, nil)
+	if err == nil {
+		t.Fatal("Get on 404 = nil error, want *FleetAPIError")
+	}
+
+	var apiErr *FleetAPIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error type = %T, want *FleetAPIError via errors.As", err)
+	}
+	if apiErr.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode = %d, want 404", apiErr.StatusCode)
+	}
+	if !strings.HasSuffix(apiErr.Snippet, "… (truncated)") {
+		t.Errorf("Snippet = %q, want it to end with the truncation suffix", apiErr.Snippet)
+	}
+	if strings.Contains(err.Error(), "TAIL-MARKER") {
+		t.Errorf("error string contains the body tail; snippet was not truncated: %q", err)
+	}
+}
+
+func TestGet429HonorsRetryAfterInline(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	start := time.Now()
+	err := c.Get(testCtx(t), "hosts", nil, nil)
+	elapsed := time.Since(start)
+
+	var apiErr *FleetAPIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error type = %T, want *FleetAPIError", err)
+	}
+	if apiErr.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("StatusCode = %d, want 429", apiErr.StatusCode)
+	}
+	if apiErr.RetryAfter != time.Second {
+		t.Errorf("RetryAfter = %v, want 1s", apiErr.RetryAfter)
+	}
+	if elapsed < 900*time.Millisecond {
+		t.Errorf("Get returned after %v, want >= ~900ms (in-line Retry-After sleep)", elapsed)
+	}
+}
+
+func TestGet429SleepHonorsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	// Cancel shortly after the request completes so Get is inside the
+	// Retry-After sleep select when ctx.Done fires.
+	ctx, cancel := context.WithCancel(testCtx(t))
+	defer cancel()
+	timer := time.AfterFunc(100*time.Millisecond, cancel)
+	defer timer.Stop()
+
+	c := newTestClient(srv)
+	start := time.Now()
+	err := c.Get(ctx, "hosts", nil, nil)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Get on 429 = nil error, want error")
+	}
+	if elapsed >= 2*time.Second {
+		t.Errorf("Get returned after %v, want < 2s (sleep select must honor ctx.Done)", elapsed)
+	}
+}
+
+func TestGetNilTargetDiscardsBody(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"hosts": []}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	if err := c.Get(testCtx(t), "hosts", nil, nil); err != nil {
+		t.Fatalf("Get with nil target unexpected error: %v", err)
+	}
+}

--- a/fleetdm/connection_config.go
+++ b/fleetdm/connection_config.go
@@ -14,6 +14,8 @@ type fleetdmConfig struct {
 	// enrollment secrets) in query results. Deliberately has no environment
 	// variable fallback: widening secret exposure must be explicit in the .spc.
 	ExposeSecrets *bool `cty:"expose_secrets"`
+	// RequestTimeout is the per-request timeout in seconds (default 30).
+	RequestTimeout *int `cty:"request_timeout"`
 }
 
 // ConfigSchema defines the schema for the plugin's connection configuration.
@@ -26,6 +28,9 @@ var ConfigSchema = map[string]*schema.Attribute{
 	},
 	"expose_secrets": {
 		Type: schema.TypeBool,
+	},
+	"request_timeout": {
+		Type: schema.TypeInt,
 	},
 }
 

--- a/fleetdm/pagination_test.go
+++ b/fleetdm/pagination_test.go
@@ -1,0 +1,250 @@
+package fleetdm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+// makeItems returns n ints so tests can hand paginateCore pages of a given size.
+func makeItems(n int) []int {
+	items := make([]int, n)
+	for i := range items {
+		items[i] = i
+	}
+	return items
+}
+
+// countingEach returns a forEachItem that counts items and always continues.
+func countingEach(seen *int) forEachItem[int] {
+	return func(int) bool {
+		*seen++
+		return true
+	}
+}
+
+func TestPaginateCoreServerClampsPerPage(t *testing.T) {
+	t.Parallel()
+
+	// The client requests per_page=1000 but the server clamps to 100 per page.
+	// paginateCore must NOT stop on len(items) < perPage; it must keep going
+	// until an empty page.
+	calls := 0
+	fetch := func(_ context.Context, page, perPage int) ([]int, *ListMeta, error) {
+		calls++
+		if perPage != 1000 {
+			t.Errorf("fetch received perPage = %d, want 1000", perPage)
+		}
+		if page < 3 {
+			return makeItems(100), nil, nil
+		}
+		return nil, nil, nil
+	}
+
+	seen := 0
+	if err := paginateCore(testCtx(t), 1000, fetch, countingEach(&seen)); err != nil {
+		t.Fatalf("paginateCore unexpected error: %v", err)
+	}
+	if seen != 300 {
+		t.Errorf("items seen = %d, want 300", seen)
+	}
+	if calls != 4 {
+		t.Errorf("fetch calls = %d, want 4 (3 full pages + 1 empty)", calls)
+	}
+}
+
+func TestPaginateCoreMetaDrivenStop(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	fetch := func(_ context.Context, page, _ int) ([]int, *ListMeta, error) {
+		calls++
+		if page < 2 {
+			return makeItems(50), &ListMeta{HasNextResults: true}, nil
+		}
+		return makeItems(50), &ListMeta{HasNextResults: false}, nil
+	}
+
+	seen := 0
+	if err := paginateCore(testCtx(t), 50, fetch, countingEach(&seen)); err != nil {
+		t.Fatalf("paginateCore unexpected error: %v", err)
+	}
+	if seen != 150 {
+		t.Errorf("items seen = %d, want 150", seen)
+	}
+	if calls != 3 {
+		t.Errorf("fetch calls = %d, want 3 (meta.has_next_results=false must stop without another fetch)", calls)
+	}
+}
+
+func TestPaginateCoreMetaFalseOnFullFirstPage(t *testing.T) {
+	t.Parallel()
+
+	// len(items) == perPage, but meta says there is nothing more: meta is
+	// authoritative and no second fetch may happen.
+	calls := 0
+	fetch := func(_ context.Context, _, _ int) ([]int, *ListMeta, error) {
+		calls++
+		return makeItems(50), &ListMeta{HasNextResults: false}, nil
+	}
+
+	seen := 0
+	if err := paginateCore(testCtx(t), 50, fetch, countingEach(&seen)); err != nil {
+		t.Fatalf("paginateCore unexpected error: %v", err)
+	}
+	if seen != 50 {
+		t.Errorf("items seen = %d, want 50", seen)
+	}
+	if calls != 1 {
+		t.Errorf("fetch calls = %d, want 1", calls)
+	}
+}
+
+func TestPaginateCoreEmptyFirstPageNoMeta(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	fetch := func(_ context.Context, _, _ int) ([]int, *ListMeta, error) {
+		calls++
+		return nil, nil, nil
+	}
+
+	seen := 0
+	if err := paginateCore(testCtx(t), 100, fetch, countingEach(&seen)); err != nil {
+		t.Fatalf("paginateCore unexpected error: %v", err)
+	}
+	if seen != 0 {
+		t.Errorf("items seen = %d, want 0", seen)
+	}
+	if calls != 1 {
+		t.Errorf("fetch calls = %d, want 1", calls)
+	}
+}
+
+func TestPaginateCoreEmptyPageWithHasNextResultsStops(t *testing.T) {
+	t.Parallel()
+
+	// A lying server: empty page but has_next_results=true. The empty-page
+	// rule wins (no data progress) so pagination must stop anyway.
+	calls := 0
+	fetch := func(_ context.Context, _, _ int) ([]int, *ListMeta, error) {
+		calls++
+		return nil, &ListMeta{HasNextResults: true}, nil
+	}
+
+	seen := 0
+	if err := paginateCore(testCtx(t), 100, fetch, countingEach(&seen)); err != nil {
+		t.Fatalf("paginateCore unexpected error: %v", err)
+	}
+	if seen != 0 {
+		t.Errorf("items seen = %d, want 0", seen)
+	}
+	if calls != 1 {
+		t.Errorf("fetch calls = %d, want 1 (empty page must terminate)", calls)
+	}
+}
+
+func TestPaginateCoreEachStopsMidPage(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	fetch := func(_ context.Context, _, _ int) ([]int, *ListMeta, error) {
+		calls++
+		return makeItems(100), &ListMeta{HasNextResults: true}, nil
+	}
+
+	seen := 0
+	each := func(int) bool {
+		seen++
+		return seen < 5 // stop on the 5th item
+	}
+
+	if err := paginateCore(testCtx(t), 100, fetch, each); err != nil {
+		t.Fatalf("paginateCore unexpected error: %v", err)
+	}
+	if seen != 5 {
+		t.Errorf("items seen = %d, want 5", seen)
+	}
+	if calls != 1 {
+		t.Errorf("fetch calls = %d, want 1 (each returning false must stop further fetches)", calls)
+	}
+}
+
+func TestPaginateCoreFetchErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	errBoom := errors.New("boom")
+	calls := 0
+	fetch := func(_ context.Context, page, _ int) ([]int, *ListMeta, error) {
+		calls++
+		if page == 0 {
+			return makeItems(10), nil, nil
+		}
+		return nil, nil, errBoom
+	}
+
+	seen := 0
+	err := paginateCore(testCtx(t), 10, fetch, countingEach(&seen))
+	if !errors.Is(err, errBoom) {
+		t.Fatalf("paginateCore error = %v, want %v", err, errBoom)
+	}
+	if seen != 10 {
+		t.Errorf("items seen before error = %d, want 10", seen)
+	}
+	if calls != 2 {
+		t.Errorf("fetch calls = %d, want 2", calls)
+	}
+}
+
+func TestShouldRetryError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "429 retries", err: &FleetAPIError{StatusCode: http.StatusTooManyRequests}, want: true},
+		{name: "500 retries", err: &FleetAPIError{StatusCode: http.StatusInternalServerError}, want: true},
+		{name: "503 retries", err: &FleetAPIError{StatusCode: http.StatusServiceUnavailable}, want: true},
+		{name: "400 does not retry", err: &FleetAPIError{StatusCode: http.StatusBadRequest}, want: false},
+		{name: "404 does not retry", err: &FleetAPIError{StatusCode: http.StatusNotFound}, want: false},
+		{name: "plain error does not retry", err: errors.New("plain"), want: false},
+		{name: "wrapped 429 retries", err: fmt.Errorf("x: %w", &FleetAPIError{StatusCode: http.StatusTooManyRequests}), want: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := shouldRetryError(context.Background(), nil, nil, tc.err); got != tc.want {
+				t.Errorf("shouldRetryError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestShouldIgnoreError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "404 ignored", err: &FleetAPIError{StatusCode: http.StatusNotFound}, want: true},
+		{name: "403 not ignored", err: &FleetAPIError{StatusCode: http.StatusForbidden}, want: false},
+		{name: "500 not ignored", err: &FleetAPIError{StatusCode: http.StatusInternalServerError}, want: false},
+		{name: "plain error not ignored", err: errors.New("plain"), want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := shouldIgnoreError(context.Background(), nil, nil, tc.err); got != tc.want {
+				t.Errorf("shouldIgnoreError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/fleetdm/plugin.go
+++ b/fleetdm/plugin.go
@@ -18,6 +18,19 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 		// Note: deliberately no NullIfZero() here — it would turn legitimate
 		// false/0 values (e.g. pack.disabled, label.host_count) into SQL NULL.
 		DefaultTransform: transform.FromGo(),
+		// Retry rate limits (429) and transient server errors (5xx) with
+		// exponential backoff; treat 404s as "no rows" rather than an error.
+		DefaultRetryConfig: &plugin.RetryConfig{
+			ShouldRetryErrorFunc: shouldRetryError,
+			MaxAttempts:          5,
+			BackoffAlgorithm:     "Exponential",
+			RetryInterval:        500,    // ms
+			CappedDuration:       30000,  // ms
+			MaxDuration:          120000, // ms
+		},
+		DefaultIgnoreConfig: &plugin.IgnoreConfig{
+			ShouldIgnoreErrorFunc: shouldIgnoreError,
+		},
 		TableMap: map[string]*plugin.Table{
 			"fleetdm_activity":             tableFleetdmActivity(ctx),
 			"fleetdm_app_store_app":        tableFleetdmAppStoreApp(ctx),

--- a/fleetdm/table_fleetdm_activity.go
+++ b/fleetdm/table_fleetdm_activity.go
@@ -31,12 +31,8 @@ type Activity struct {
 // The API returns {"activities": [...]}
 type ListActivitiesResponse struct {
 	Activities []Activity `json:"activities"`
-	Meta       struct {   // FleetDM API for activities includes a meta object for pagination
-		HasNextResults     bool   `json:"has_next_results"`
-		HasPreviousResults bool   `json:"has_previous_results"`
-		NextCursor         string `json:"next_cursor"` // The API docs mention 'after' parameter with a timestamp, but also page/per_page. Let's assume page/per_page for now as per examples.
-	} `json:"meta"`
-	Count int `json:"count"` // Total count of activities matching the query
+	Meta       *ListMeta  `json:"meta"`
+	Count      int        `json:"count"` // Total count of activities matching the query
 }
 
 func tableFleetdmActivity(ctx context.Context) *plugin.Table {
@@ -74,24 +70,13 @@ func tableFleetdmActivity(ctx context.Context) *plugin.Table {
 }
 
 func listActivities(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	client, err := NewFleetDMClient(ctx, d.Connection)
+	client, err := getClient(ctx, d)
 	if err != nil {
 		plugin.Logger(ctx).Error("fleetdm_activity.listActivities", "connection_error", err)
 		return nil, err
 	}
 
-	// Pagination for activities: The /api/v1/fleet/activities endpoint supports `page` and `per_page`
-	// It also supports `after` (timestamp string like "2022-11-22T17:39:00Z") for cursor-based pagination.
-	// We'll use page/per_page for consistency with other tables.
-	page := 0
-	perPage := 50 // API default is 20, max 100
-
-	// limit := d.QueryContext.Limit
-	// if limit != nil && *limit < int64(perPage) {
-	// 	// perPage = int(*limit)
-	// }
-
-	for {
+	err = paginatedList(ctx, d, 50, func(ctx context.Context, page, perPage int) ([]Activity, *ListMeta, error) {
 		params := url.Values{}
 		params.Add("page", strconv.Itoa(page))
 		params.Add("per_page", strconv.Itoa(perPage))
@@ -112,32 +97,14 @@ func listActivities(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateD
 		}
 
 		var response ListActivitiesResponse
-		_, err := client.Get(ctx, "activities", params, &response)
-		if err != nil {
+		if err := client.Get(ctx, "activities", params, &response); err != nil {
 			plugin.Logger(ctx).Error("fleetdm_activity.listActivities", "api_error", err, "page", page, "params", params.Encode())
-			return nil, err
+			return nil, nil, err
 		}
-
-		for _, activity := range response.Activities {
-			d.StreamListItem(ctx, activity)
-			if d.RowsRemaining(ctx) == 0 {
-				plugin.Logger(ctx).Debug("fleetdm_activity.listActivities", "limit_reached", true)
-				return nil, nil
-			}
-		}
-
-		// Pagination check
-		if !response.Meta.HasNextResults && response.Meta.NextCursor == "" {
-			plugin.Logger(ctx).Debug("fleetdm_activity.listActivities", "end_of_results_by_meta", true, "activities_on_page", len(response.Activities), "has_next_meta", response.Meta.HasNextResults)
-			break
-		}
-		if len(response.Activities) < perPage { // Fallback if meta isn't conclusive with page/per_page
-			plugin.Logger(ctx).Debug("fleetdm_activity.listActivities", "end_of_results_by_count", true, "activities_on_page", len(response.Activities))
-			break
-		}
-
-		page++
-		plugin.Logger(ctx).Debug("fleetdm_activity.listActivities", "next_page", page)
+		return response.Activities, response.Meta, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return nil, nil

--- a/fleetdm/table_fleetdm_app_store_app.go
+++ b/fleetdm/table_fleetdm_app_store_app.go
@@ -72,7 +72,7 @@ func tableFleetdmAppStoreApp(ctx context.Context) *plugin.Table {
 }
 
 func listAppStoreApps(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	client, err := NewFleetDMClient(ctx, d.Connection)
+	client, err := getClient(ctx, d)
 	if err != nil {
 		plugin.Logger(ctx).Error("fleetdm_app_store_app.listAppStoreApps", "connection_error", err)
 		return nil, err
@@ -98,31 +98,28 @@ func listAppStoreApps(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 		plugin.Logger(ctx).Info("fleetdm_app_store_app.listAppStoreApps", "using_specific_team_id", teamID)
 	} else {
 		// Auto-discover all teams by calling GET /api/v1/fleet/teams.
+		// This is a nested full fetch (not a stream), so it uses a plain page
+		// loop that terminates on the first empty page.
 		plugin.Logger(ctx).Info("fleetdm_app_store_app.listAppStoreApps", "discovering_all_teams", true)
 
-		page := 0
-		perPage := 10000
-
-		for {
+		perPage := 100
+		for page := 0; ; page++ {
 			params := url.Values{}
 			params.Add("page", strconv.Itoa(page))
 			params.Add("per_page", strconv.Itoa(perPage))
 
 			var teamsResponse ListTeamsResponse
-			_, err := client.Get(ctx, "teams", params, &teamsResponse)
-			if err != nil {
+			if err := client.Get(ctx, "teams", params, &teamsResponse); err != nil {
 				plugin.Logger(ctx).Error("fleetdm_app_store_app.listAppStoreApps", "teams_api_error", err, "page", page)
 				return nil, err
 			}
 
+			if len(teamsResponse.Teams) == 0 {
+				break
+			}
 			for _, team := range teamsResponse.Teams {
 				teamsToQuery = append(teamsToQuery, teamInfo{ID: team.ID, Name: team.Name})
 			}
-
-			if len(teamsResponse.Teams) < perPage {
-				break
-			}
-			page++
 		}
 
 		plugin.Logger(ctx).Info("fleetdm_app_store_app.listAppStoreApps", "total_teams_discovered", len(teamsToQuery))
@@ -134,8 +131,7 @@ func listAppStoreApps(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 		params.Add("team_id", strconv.FormatUint(uint64(team.ID), 10))
 
 		var response ListAppStoreAppsResponse
-		_, err := client.Get(ctx, "software/app_store_apps", params, &response)
-		if err != nil {
+		if err := client.Get(ctx, "software/app_store_apps", params, &response); err != nil {
 			// Teams without a VPP token (or without the required license) return
 			// 4xx here; that must not abort the results of the other teams.
 			plugin.Logger(ctx).Warn("fleetdm_app_store_app.listAppStoreApps", "skipping_team", team.ID, "api_error", err)

--- a/fleetdm/table_fleetdm_carve.go
+++ b/fleetdm/table_fleetdm_carve.go
@@ -63,16 +63,13 @@ func tableFleetdmCarve(ctx context.Context) *plugin.Table {
 }
 
 func listCarves(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	client, err := NewFleetDMClient(ctx, d.Connection)
+	client, err := getClient(ctx, d)
 	if err != nil {
 		plugin.Logger(ctx).Error("fleetdm_carve.listCarves", "connection_error", err)
 		return nil, err
 	}
 
-	page := 0
-	perPage := 50
-
-	for {
+	err = paginatedList(ctx, d, 100, func(ctx context.Context, page, perPage int) ([]Carve, *ListMeta, error) {
 		params := url.Values{}
 		params.Add("page", strconv.Itoa(page))
 		params.Add("per_page", strconv.Itoa(perPage))
@@ -81,29 +78,15 @@ func listCarves(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData)
 		params.Add("expired", "true")         // Also get expired carves
 
 		var response ListCarvesResponse
-		_, err := client.Get(ctx, "carves", params, &response)
-		if err != nil {
+		if err := client.Get(ctx, "carves", params, &response); err != nil {
 			plugin.Logger(ctx).Error("fleetdm_carve.listCarves", "api_error", err, "page", page, "params", params.Encode())
-			return nil, err
+			return nil, nil, err
 		}
-
-		for _, carve := range response.Carves {
-			d.StreamListItem(ctx, carve)
-			if d.RowsRemaining(ctx) == 0 {
-				plugin.Logger(ctx).Debug("fleetdm_carve.listCarves", "limit_reached", true)
-				return nil, nil
-			}
-		}
-
-		// The /carves endpoint does not specify a meta object for pagination,
-		// so we rely on the number of items returned.
-		if len(response.Carves) < perPage {
-			plugin.Logger(ctx).Debug("fleetdm_carve.listCarves", "end_of_results", true, "carves_on_page", len(response.Carves))
-			break
-		}
-
-		page++
-		plugin.Logger(ctx).Debug("fleetdm_carve.listCarves", "next_page", page)
+		// The /carves endpoint does not document a meta object for pagination.
+		return response.Carves, nil, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return nil, nil

--- a/fleetdm/table_fleetdm_fleet_maintained_app.go
+++ b/fleetdm/table_fleetdm_fleet_maintained_app.go
@@ -25,10 +25,7 @@ type FleetMaintainedApp struct {
 // ListFleetMaintainedAppsResponse is the expected structure for the list Fleet-maintained apps API call.
 type ListFleetMaintainedAppsResponse struct {
 	FleetMaintainedApps []FleetMaintainedApp `json:"fleet_maintained_apps"`
-	Meta                struct {
-		HasNextResults     bool `json:"has_next_results"`
-		HasPreviousResults bool `json:"has_previous_results"`
-	} `json:"meta"`
+	Meta                *ListMeta            `json:"meta"`
 }
 
 func tableFleetdmFleetMaintainedApp(ctx context.Context) *plugin.Table {
@@ -58,16 +55,14 @@ func tableFleetdmFleetMaintainedApp(ctx context.Context) *plugin.Table {
 }
 
 func listFleetMaintainedApps(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	client, err := NewFleetDMClient(ctx, d.Connection)
+	client, err := getClient(ctx, d)
 	if err != nil {
 		plugin.Logger(ctx).Error("fleetdm_fleet_maintained_app.listFleetMaintainedApps", "connection_error", err)
 		return nil, err
 	}
 
-	page := 0
-	perPage := 10000
-
-	for {
+	// Bulk endpoint: large pages keep the page count low on big catalogs.
+	err = paginatedList(ctx, d, 1000, func(ctx context.Context, page, perPage int) ([]FleetMaintainedApp, *ListMeta, error) {
 		params := url.Values{}
 		params.Add("page", strconv.Itoa(page))
 		params.Add("per_page", strconv.Itoa(perPage))
@@ -77,39 +72,15 @@ func listFleetMaintainedApps(ctx context.Context, d *plugin.QueryData, h *plugin
 		}
 
 		var response ListFleetMaintainedAppsResponse
-		_, err := client.Get(ctx, "software/fleet_maintained_apps", params, &response) // Endpoint is /api/v1/fleet/software/fleet_maintained_apps
-		if err != nil {
+		if err := client.Get(ctx, "software/fleet_maintained_apps", params, &response); err != nil {
 			plugin.Logger(ctx).Error("fleetdm_fleet_maintained_app.listFleetMaintainedApps", "api_error", err, "page", page, "params", params.Encode())
-			return nil, err
+			return nil, nil, err
 		}
-
-		for _, app := range response.FleetMaintainedApps {
-			d.StreamListItem(ctx, app)
-			if d.RowsRemaining(ctx) == 0 {
-				plugin.Logger(ctx).Debug("fleetdm_fleet_maintained_app.listFleetMaintainedApps", "limit_reached_sdk", "true")
-				return nil, nil
-			}
-		}
-
-		plugin.Logger(ctx).Info("fleetdm_fleet_maintained_app.listFleetMaintainedApps",
-			"page_processed", page,
-			"items_on_page", len(response.FleetMaintainedApps),
-			"api_has_next_results", response.Meta.HasNextResults,
-		)
-
-		if len(response.FleetMaintainedApps) < perPage {
-			plugin.Logger(ctx).Info("fleetdm_fleet_maintained_app.listFleetMaintainedApps", "pagination_ended_item_count_less_than_per_page", true, "current_page", page, "items_on_page", len(response.FleetMaintainedApps), "per_page", perPage)
-			break
-		}
-
-		if !response.Meta.HasNextResults && len(response.FleetMaintainedApps) == perPage {
-			plugin.Logger(ctx).Warn("fleetdm_fleet_maintained_app.listFleetMaintainedApps", "api_has_next_results_is_false_but_full_page_received", true, "current_page", page)
-		}
-
-		page++
-		plugin.Logger(ctx).Debug("fleetdm_fleet_maintained_app.listFleetMaintainedApps", "incrementing_to_next_page", page)
+		return response.FleetMaintainedApps, response.Meta, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
-	plugin.Logger(ctx).Info("fleetdm_fleet_maintained_app.listFleetMaintainedApps", "list_fleet_maintained_apps_completed", true)
 	return nil, nil
 }

--- a/fleetdm/table_fleetdm_host.go
+++ b/fleetdm/table_fleetdm_host.go
@@ -293,21 +293,18 @@ func addHostPopulationParams(params url.Values) {
 
 // listHosts fetches a list of hosts from the FleetDM API.
 func listHosts(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	client, err := NewFleetDMClient(ctx, d.Connection)
+	client, err := getClient(ctx, d)
 	if err != nil {
 		plugin.Logger(ctx).Error("fleetdm_host.listHosts", "connection_error", err)
 		return nil, err
 	}
 
-	page := 0
-	perPage := 100
-
-	for {
+	err = paginatedList(ctx, d, 100, func(ctx context.Context, page, perPage int) ([]Host, *ListMeta, error) {
 		params := url.Values{}
 		params.Add("page", strconv.Itoa(page))
 		params.Add("per_page", strconv.Itoa(perPage))
 		params.Add("order_key", "id")
-		params.Add("order_direction", "desc") // Get latest hosts first, or 'asc' for consistent paging
+		params.Add("order_direction", "asc") // Ascending ID keeps offset paging stable while iterating
 
 		addHostPopulationParams(params)
 
@@ -349,27 +346,15 @@ func listHosts(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) 
 		plugin.Logger(ctx).Debug("fleetdm_host.listHosts", "request_params", params.Encode())
 
 		var response ListHostsResponse
-		_, err := client.Get(ctx, "hosts", params, &response)
-		if err != nil {
+		if err := client.Get(ctx, "hosts", params, &response); err != nil {
 			plugin.Logger(ctx).Error("fleetdm_host.listHosts", "api_error", err, "page", page, "params", params.Encode())
-			return nil, err
+			return nil, nil, err
 		}
-
-		for _, host := range response.Hosts {
-			d.StreamListItem(ctx, host)
-			if d.RowsRemaining(ctx) == 0 {
-				plugin.Logger(ctx).Debug("fleetdm_host.listHosts", "limit_reached", true)
-				return nil, nil
-			}
-		}
-
-		if len(response.Hosts) < perPage {
-			plugin.Logger(ctx).Debug("fleetdm_host.listHosts", "end_of_results", true, "hosts_count_on_page", len(response.Hosts))
-			break
-		}
-
-		page++
-		plugin.Logger(ctx).Debug("fleetdm_host.listHosts", "next_page", page)
+		// GET /hosts does not document a meta object for pagination.
+		return response.Hosts, nil, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return nil, nil

--- a/fleetdm/table_fleetdm_host_detail.go
+++ b/fleetdm/table_fleetdm_host_detail.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strconv"
 
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
@@ -180,10 +181,18 @@ func tableFleetdmHostDetail(ctx context.Context) *plugin.Table {
 		Description: "Provides fully detailed information for each host by fetching details individually.",
 		List: &plugin.ListConfig{
 			Hydrate: listHostsForDetails,
+			KeyColumns: []*plugin.KeyColumn{
+				{Name: "team_id", Require: plugin.Optional},
+				{Name: "status", Require: plugin.Optional},
+				{Name: "query", Require: plugin.Optional},
+			},
 		},
 		Get: &plugin.GetConfig{
 			KeyColumns: plugin.SingleColumn("id"),
 			Hydrate:    getHostDetails,
+		},
+		HydrateConfig: []plugin.HydrateConfig{
+			{Func: getHostDetails, MaxConcurrency: 10},
 		},
 		Columns: []*plugin.Column{
 			// Columns from the basic host list call (NO HYDRATE)
@@ -253,46 +262,50 @@ func tableFleetdmHostDetail(ctx context.Context) *plugin.Table {
 			{Name: "maintenance_window", Type: proto.ColumnType_JSON, Hydrate: getHostDetails, Transform: transform.FromField("MaintenanceWindow").Transform(arrayOrObjectToJSONString), Description: "Configured maintenance window for the host."},
 			{Name: "additional", Type: proto.ColumnType_JSON, Hydrate: getHostDetails, Transform: transform.FromField("Additional").Transform(arrayOrObjectToJSONString), Description: "Additional custom details for the host."},
 			{Name: "packs", Type: proto.ColumnType_JSON, Hydrate: getHostDetails, Transform: transform.FromField("Packs").Transform(arrayOrObjectToJSONString), Description: "Query packs applied to the host."},
+
+			// Query parameters that can be used for filtering (key columns)
+			{Name: "query", Type: proto.ColumnType_STRING, Transform: transform.FromQual("query"), Description: "Search query keywords for hostname, UUID, serial number, or IP. Set in WHERE clause."},
 		},
 	}
 }
 
 // listHostsForDetails gets the minimal host object for hydration.
 func listHostsForDetails(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	client, err := NewFleetDMClient(ctx, d.Connection)
+	client, err := getClient(ctx, d)
 	if err != nil {
 		plugin.Logger(ctx).Error("fleetdm_host_detail.listHostsForDetails", "connection_error", err)
 		return nil, err
 	}
 
-	page := 0
-	perPage := 10000
-
-	for {
+	// Large pages: this list only feeds the per-host detail hydrate, so fewer,
+	// bigger list calls are cheaper than many small ones.
+	err = paginatedList(ctx, d, 500, func(ctx context.Context, page, perPage int) ([]Host, *ListMeta, error) {
 		params := url.Values{}
-		params.Add("page", fmt.Sprintf("%d", page))
-		params.Add("per_page", fmt.Sprintf("%d", perPage))
+		params.Add("page", strconv.Itoa(page))
+		params.Add("per_page", strconv.Itoa(perPage))
 		params.Add("order_key", "id")
 		params.Add("order_direction", "asc")
 
+		if d.EqualsQuals["team_id"] != nil {
+			params.Add("team_id", strconv.FormatInt(d.EqualsQuals["team_id"].GetInt64Value(), 10))
+		}
+		if d.EqualsQuals["status"] != nil {
+			params.Add("status", d.EqualsQuals["status"].GetStringValue())
+		}
+		if d.EqualsQuals["query"] != nil {
+			params.Add("query", d.EqualsQuals["query"].GetStringValue())
+		}
+
 		var response ListHostsResponse
-		_, err := client.Get(ctx, "hosts", params, &response)
-		if err != nil {
+		if err := client.Get(ctx, "hosts", params, &response); err != nil {
 			plugin.Logger(ctx).Error("fleetdm_host_detail.listHostsForDetails", "api_error", err, "page", page)
-			return nil, err
+			return nil, nil, err
 		}
-
-		for _, host := range response.Hosts {
-			d.StreamListItem(ctx, host)
-			if d.RowsRemaining(ctx) == 0 {
-				return nil, nil
-			}
-		}
-
-		if len(response.Hosts) < perPage {
-			break
-		}
-		page++
+		// GET /hosts does not document a meta object for pagination.
+		return response.Hosts, nil, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return nil, nil
@@ -303,7 +316,10 @@ func getHostDetails(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateD
 	var hostID int
 	if h.Item != nil {
 		// h.Item is the minimal Host object from listHostsForDetails
-		hostFromList := h.Item.(Host) // Use the simpler Host struct here
+		hostFromList, ok := h.Item.(Host)
+		if !ok {
+			return nil, fmt.Errorf("getHostDetails: unexpected item type %T, expected Host", h.Item)
+		}
 		hostID = hostFromList.ID
 	} else {
 		hostID = int(d.EqualsQuals["id"].GetInt64Value())
@@ -315,7 +331,7 @@ func getHostDetails(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateD
 
 	plugin.Logger(ctx).Info("fleetdm_host_detail.getHostDetails", "hydrating_host_id", hostID)
 
-	client, err := NewFleetDMClient(ctx, d.Connection)
+	client, err := getClient(ctx, d)
 	if err != nil {
 		plugin.Logger(ctx).Error("fleetdm_host_detail.getHostDetails", "connection_error", err, "host_id", hostID)
 		return nil, err
@@ -328,9 +344,7 @@ func getHostDetails(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateD
 		Host HostDetail `json:"host"` // Use the new rich HostDetail struct
 	}
 	endpointPath := fmt.Sprintf("hosts/%d", hostID)
-	_, err = client.Get(ctx, endpointPath, params, &response)
-
-	if err != nil {
+	if err := client.Get(ctx, endpointPath, params, &response); err != nil {
 		plugin.Logger(ctx).Error("fleetdm_host_detail.getHostDetails", "client_get_error", err, "host_id", hostID)
 		return nil, err
 	}

--- a/fleetdm/table_fleetdm_label.go
+++ b/fleetdm/table_fleetdm_label.go
@@ -72,22 +72,13 @@ func tableFleetdmLabel(ctx context.Context) *plugin.Table {
 }
 
 func listLabels(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	client, err := NewFleetDMClient(ctx, d.Connection)
+	client, err := getClient(ctx, d)
 	if err != nil {
 		plugin.Logger(ctx).Error("fleetdm_label.listLabels", "connection_error", err)
 		return nil, err
 	}
 
-	// Pagination for labels: The /api/v1/fleet/labels endpoint supports `page` and `per_page`
-	page := 0
-	perPage := 50 // API default is 20, max 100
-
-	// limit := d.QueryContext.Limit
-	// if limit != nil && *limit < int64(perPage) {
-	// 	// perPage = int(*limit)
-	// }
-
-	for {
+	err = paginatedList(ctx, d, 100, func(ctx context.Context, page, perPage int) ([]Label, *ListMeta, error) {
 		params := url.Values{}
 		params.Add("page", strconv.Itoa(page))
 		params.Add("per_page", strconv.Itoa(perPage))
@@ -97,29 +88,15 @@ func listLabels(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData)
 		}
 
 		var response ListLabelsResponse
-		_, err := client.Get(ctx, "labels", params, &response)
-		if err != nil {
+		if err := client.Get(ctx, "labels", params, &response); err != nil {
 			plugin.Logger(ctx).Error("fleetdm_label.listLabels", "api_error", err, "page", page, "params", params.Encode())
-			return nil, err
+			return nil, nil, err
 		}
-
-		for _, label := range response.Labels {
-			d.StreamListItem(ctx, label)
-			if d.RowsRemaining(ctx) == 0 {
-				plugin.Logger(ctx).Debug("fleetdm_label.listLabels", "limit_reached", true)
-				return nil, nil
-			}
-		}
-
-		// Pagination check: if the number of labels returned is less than per_page,
-		// it's likely the last page. The /labels endpoint does not specify a `meta.has_next_results`.
-		if len(response.Labels) < perPage {
-			plugin.Logger(ctx).Debug("fleetdm_label.listLabels", "end_of_results", true, "labels_on_page", len(response.Labels))
-			break
-		}
-
-		page++
-		plugin.Logger(ctx).Debug("fleetdm_label.listLabels", "next_page", page)
+		// The /labels endpoint does not document a meta object for pagination.
+		return response.Labels, nil, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return nil, nil

--- a/fleetdm/table_fleetdm_os_version.go
+++ b/fleetdm/table_fleetdm_os_version.go
@@ -39,13 +39,10 @@ type OSVersion struct {
 
 // ListOSVersionsResponse is the expected structure for the list OS versions API call.
 type ListOSVersionsResponse struct {
-	OSVersions []OSVersion `json:"os_versions"`
-	Meta       struct {
-		HasNextResults     bool `json:"has_next_results"`
-		HasPreviousResults bool `json:"has_previous_results"`
-	} `json:"meta"`
-	Count           int        `json:"count"`
-	CountsUpdatedAt *FleetTime `json:"counts_updated_at"`
+	OSVersions      []OSVersion `json:"os_versions"`
+	Meta            *ListMeta   `json:"meta"`
+	Count           int         `json:"count"`
+	CountsUpdatedAt *FleetTime  `json:"counts_updated_at"`
 }
 
 func tableFleetdmOSVersion(ctx context.Context) *plugin.Table {
@@ -82,16 +79,14 @@ func tableFleetdmOSVersion(ctx context.Context) *plugin.Table {
 }
 
 func listOSVersions(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	client, err := NewFleetDMClient(ctx, d.Connection)
+	client, err := getClient(ctx, d)
 	if err != nil {
 		plugin.Logger(ctx).Error("fleetdm_os_version.listOSVersions", "connection_error", err)
 		return nil, err
 	}
 
-	page := 0
-	perPage := 10000
-
-	for {
+	// Bulk endpoint: large pages keep the page count low on big fleets.
+	err = paginatedList(ctx, d, 1000, func(ctx context.Context, page, perPage int) ([]OSVersion, *ListMeta, error) {
 		params := url.Values{}
 		params.Add("page", strconv.Itoa(page))
 		params.Add("per_page", strconv.Itoa(perPage))
@@ -112,40 +107,15 @@ func listOSVersions(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateD
 		}
 
 		var response ListOSVersionsResponse
-		_, err := client.Get(ctx, "os_versions", params, &response) // Endpoint is /api/v1/fleet/os_versions
-		if err != nil {
+		if err := client.Get(ctx, "os_versions", params, &response); err != nil {
 			plugin.Logger(ctx).Error("fleetdm_os_version.listOSVersions", "api_error", err, "page", page, "params", params.Encode())
-			return nil, err
+			return nil, nil, err
 		}
-
-		for _, osVer := range response.OSVersions {
-			d.StreamListItem(ctx, osVer)
-			if d.RowsRemaining(ctx) == 0 {
-				plugin.Logger(ctx).Debug("fleetdm_os_version.listOSVersions", "limit_reached_sdk", "true")
-				return nil, nil
-			}
-		}
-
-		plugin.Logger(ctx).Info("fleetdm_os_version.listOSVersions",
-			"page_processed", page,
-			"items_on_page", len(response.OSVersions),
-			"api_total_count", response.Count,
-			"api_has_next_results", response.Meta.HasNextResults,
-		)
-
-		if len(response.OSVersions) < perPage {
-			plugin.Logger(ctx).Info("fleetdm_os_version.listOSVersions", "pagination_ended_item_count_less_than_per_page", true, "current_page", page, "items_on_page", len(response.OSVersions), "per_page", perPage)
-			break
-		}
-
-		if !response.Meta.HasNextResults && len(response.OSVersions) == perPage {
-			plugin.Logger(ctx).Warn("fleetdm_os_version.listOSVersions", "api_has_next_results_is_false_but_full_page_received", true, "current_page", page)
-		}
-
-		page++
-		plugin.Logger(ctx).Debug("fleetdm_os_version.listOSVersions", "incrementing_to_next_page", page)
+		return response.OSVersions, response.Meta, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
-	plugin.Logger(ctx).Info("fleetdm_os_version.listOSVersions", "list_os_versions_completed", true)
 	return nil, nil
 }

--- a/fleetdm/table_fleetdm_pack.go
+++ b/fleetdm/table_fleetdm_pack.go
@@ -93,22 +93,13 @@ func tableFleetdmPack(ctx context.Context) *plugin.Table {
 }
 
 func listPacks(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	client, err := NewFleetDMClient(ctx, d.Connection)
+	client, err := getClient(ctx, d)
 	if err != nil {
 		plugin.Logger(ctx).Error("fleetdm_pack.listPacks", "connection_error", err)
 		return nil, err
 	}
 
-	// Pagination for packs: The /api/v1/fleet/packs endpoint supports `page` and `per_page`
-	page := 0
-	perPage := 50 // API default is 20, max 100
-
-	// limit := d.QueryContext.Limit
-	// if limit != nil && *limit < int64(perPage) {
-	// 	// perPage = int(*limit)
-	// }
-
-	for {
+	err = paginatedList(ctx, d, 100, func(ctx context.Context, page, perPage int) ([]Pack, *ListMeta, error) {
 		params := url.Values{}
 		params.Add("page", strconv.Itoa(page))
 		params.Add("per_page", strconv.Itoa(perPage))
@@ -118,32 +109,17 @@ func listPacks(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) 
 		// }
 
 		var response ListPacksResponse
-		_, err := client.Get(ctx, "packs", params, &response)
-		if err != nil {
+		if err := client.Get(ctx, "packs", params, &response); err != nil {
 			plugin.Logger(ctx).Error("fleetdm_pack.listPacks", "api_error", err, "page", page, "params", params.Encode())
-			return nil, err
+			return nil, nil, err
 		}
-
-		for _, pack := range response.Packs {
-			// List endpoint for packs usually provides summary data.
-			// Detailed fields like 'targets', 'scheduled_queries', 'agent_options' are from GET /packs/{id}.
-			// These will be null/empty here and populated by getPack if a single item is fetched.
-			d.StreamListItem(ctx, pack)
-			if d.RowsRemaining(ctx) == 0 {
-				plugin.Logger(ctx).Debug("fleetdm_pack.listPacks", "limit_reached", true)
-				return nil, nil
-			}
-		}
-
-		// Pagination check: if the number of packs returned is less than per_page,
-		// it's likely the last page. The /packs endpoint does not specify a `meta.has_next_results`.
-		if len(response.Packs) < perPage {
-			plugin.Logger(ctx).Debug("fleetdm_pack.listPacks", "end_of_results", true, "packs_on_page", len(response.Packs))
-			break
-		}
-
-		page++
-		plugin.Logger(ctx).Debug("fleetdm_pack.listPacks", "next_page", page)
+		// The /packs endpoint does not document a meta object for pagination.
+		// List endpoint for packs provides summary data; detailed fields like
+		// 'targets', 'scheduled_queries', 'agent_options' come from GET /packs/{id}.
+		return response.Packs, nil, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return nil, nil

--- a/fleetdm/table_fleetdm_policy.go
+++ b/fleetdm/table_fleetdm_policy.go
@@ -85,19 +85,11 @@ func tableFleetdmPolicy(ctx context.Context) *plugin.Table {
 }
 
 func listPolicies(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	client, err := NewFleetDMClient(ctx, d.Connection)
+	client, err := getClient(ctx, d)
 	if err != nil {
 		plugin.Logger(ctx).Error("fleetdm_policy.listPolicies", "connection_error", err)
 		return nil, err
 	}
-
-	page := 0
-	perPage := 50
-
-	// limit := d.QueryContext.Limit
-	// if limit != nil && *limit < int64(perPage) {
-	// 	// perPage = int(*limit)
-	// }
 
 	// Determine endpoint: global/policies or teams/:id/policies
 	endpoint := "global/policies"
@@ -107,7 +99,7 @@ func listPolicies(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDat
 		plugin.Logger(ctx).Debug("fleetdm_policy.listPolicies", "using_team_endpoint", endpoint)
 	}
 
-	for {
+	err = paginatedList(ctx, d, 100, func(ctx context.Context, page, perPage int) ([]Policy, *ListMeta, error) {
 		params := url.Values{}
 		params.Add("page", strconv.Itoa(page))
 		params.Add("per_page", strconv.Itoa(perPage))
@@ -123,27 +115,15 @@ func listPolicies(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDat
 		}
 
 		var response ListPoliciesResponse
-		_, err := client.Get(ctx, endpoint, params, &response)
-		if err != nil {
+		if err := client.Get(ctx, endpoint, params, &response); err != nil {
 			plugin.Logger(ctx).Error("fleetdm_policy.listPolicies", "api_error", err, "page", page, "params", params.Encode(), "endpoint", endpoint)
-			return nil, err
+			return nil, nil, err
 		}
-
-		for _, policy := range response.Policies {
-			d.StreamListItem(ctx, policy)
-			if d.RowsRemaining(ctx) == 0 {
-				plugin.Logger(ctx).Debug("fleetdm_policy.listPolicies", "limit_reached", true)
-				return nil, nil
-			}
-		}
-
-		if len(response.Policies) < perPage {
-			plugin.Logger(ctx).Debug("fleetdm_policy.listPolicies", "end_of_results", true, "policies_on_page", len(response.Policies))
-			break
-		}
-
-		page++
-		plugin.Logger(ctx).Debug("fleetdm_policy.listPolicies", "next_page", page)
+		// The policies endpoints do not document a meta object for pagination.
+		return response.Policies, nil, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return nil, nil

--- a/fleetdm/table_fleetdm_query.go
+++ b/fleetdm/table_fleetdm_query.go
@@ -98,21 +98,13 @@ func tableFleetdmQuery(ctx context.Context) *plugin.Table {
 }
 
 func listQueries(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	client, err := NewFleetDMClient(ctx, d.Connection)
+	client, err := getClient(ctx, d)
 	if err != nil {
 		plugin.Logger(ctx).Error("fleetdm_query.listQueries", "connection_error", err)
 		return nil, err
 	}
 
-	page := 0
-	perPage := 50 // API default is 20, max 100
-
-	// limit := d.QueryContext.Limit
-	// if limit != nil && *limit < int64(perPage) {
-	// 	// perPage = int(*limit)
-	// }
-
-	for {
+	err = paginatedList(ctx, d, 100, func(ctx context.Context, page, perPage int) ([]QuerySaved, *ListMeta, error) {
 		params := url.Values{}
 		params.Add("page", strconv.Itoa(page))
 		params.Add("per_page", strconv.Itoa(perPage))
@@ -132,30 +124,17 @@ func listQueries(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData
 		// TODO: Support order_key and order_direction via Quals
 
 		var response ListQueriesResponse
-		_, err := client.Get(ctx, "queries", params, &response)
-		if err != nil {
+		if err := client.Get(ctx, "queries", params, &response); err != nil {
 			plugin.Logger(ctx).Error("fleetdm_query.listQueries", "api_error", err, "page", page, "params", params.Encode())
-			return nil, err
+			return nil, nil, err
 		}
-
-		for _, query := range response.Queries {
-			// The list endpoint for queries might not include 'packs'.
-			// 'packs' are listed in the response for GET /api/v1/fleet/queries/{id}.
-			// So, for list, 'packs' will be nil/empty.
-			d.StreamListItem(ctx, query)
-			if d.RowsRemaining(ctx) == 0 {
-				plugin.Logger(ctx).Debug("fleetdm_query.listQueries", "limit_reached", true)
-				return nil, nil
-			}
-		}
-
-		if len(response.Queries) < perPage {
-			plugin.Logger(ctx).Debug("fleetdm_query.listQueries", "end_of_results", true, "queries_on_page", len(response.Queries))
-			break
-		}
-
-		page++
-		plugin.Logger(ctx).Debug("fleetdm_query.listQueries", "next_page", page)
+		// The /queries endpoint does not document a meta object for pagination.
+		// 'packs' is only populated by GET /api/v1/fleet/queries/{id}, so it is
+		// nil/empty for list rows.
+		return response.Queries, nil, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return nil, nil

--- a/fleetdm/table_fleetdm_software_title.go
+++ b/fleetdm/table_fleetdm_software_title.go
@@ -39,13 +39,10 @@ type SoftwareTitle struct {
 
 // ListSoftwareTitlesResponse is the expected structure for the list software titles API call.
 type ListSoftwareTitlesResponse struct {
-	SoftwareTitles []SoftwareTitle `json:"software_titles"`
-	Meta           struct {
-		HasNextResults     bool `json:"has_next_results"`
-		HasPreviousResults bool `json:"has_previous_results"`
-	} `json:"meta"`
-	Count           int        `json:"count"`
-	CountsUpdatedAt *FleetTime `json:"counts_updated_at"`
+	SoftwareTitles  []SoftwareTitle `json:"software_titles"`
+	Meta            *ListMeta       `json:"meta"`
+	Count           int             `json:"count"`
+	CountsUpdatedAt *FleetTime      `json:"counts_updated_at"`
 }
 
 func tableFleetdmSoftwareTitle(ctx context.Context) *plugin.Table {
@@ -93,8 +90,8 @@ func tableFleetdmSoftwareTitle(ctx context.Context) *plugin.Table {
 			{Name: "query", Type: proto.ColumnType_STRING, Transform: transform.FromQual("query"), Description: "Search query keywords. Searchable fields include title and CVE. Set in WHERE clause."},
 			{Name: "self_service", Type: proto.ColumnType_BOOL, Transform: transform.FromQual("self_service"), Description: "Filter for self-service software only. Set in WHERE clause."},
 			{Name: "packages_only", Type: proto.ColumnType_BOOL, Transform: transform.FromQual("packages_only"), Description: "Filter for install packages only, excluding app store apps (Fleet Premium). Set in WHERE clause."},
-			{Name: "min_cvss_score", Type: proto.ColumnType_INT, Transform: transform.FromQual("min_cvss_score"), Description: "Filter for software with vulnerabilities having a CVSS v3.x base score higher than this value (Fleet Premium). Set in WHERE clause."},
-			{Name: "max_cvss_score", Type: proto.ColumnType_INT, Transform: transform.FromQual("max_cvss_score"), Description: "Filter for software with vulnerabilities having a CVSS v3.x base score lower than this value (Fleet Premium). Set in WHERE clause."},
+			{Name: "min_cvss_score", Type: proto.ColumnType_DOUBLE, Transform: transform.FromQual("min_cvss_score"), Description: "Filter for software with vulnerabilities having a CVSS v3.x base score higher than this value (Fleet Premium). Set in WHERE clause."},
+			{Name: "max_cvss_score", Type: proto.ColumnType_DOUBLE, Transform: transform.FromQual("max_cvss_score"), Description: "Filter for software with vulnerabilities having a CVSS v3.x base score lower than this value (Fleet Premium). Set in WHERE clause."},
 			{Name: "exploit", Type: proto.ColumnType_BOOL, Transform: transform.FromQual("exploit"), Description: "Filter for software with vulnerabilities that have been actively exploited in the wild — CISA known exploit (Fleet Premium). Set in WHERE clause."},
 			{Name: "platform", Type: proto.ColumnType_STRING, Transform: transform.FromQual("platform"), Description: "Filter installable titles by platform. Options: 'macos', 'darwin', 'windows', 'linux', 'chrome', 'ios', 'ipados'. Requires team_id. Set in WHERE clause."},
 			{Name: "exclude_fleet_maintained_apps", Type: proto.ColumnType_BOOL, Transform: transform.FromQual("exclude_fleet_maintained_apps"), Description: "Exclude Fleet-maintained apps from the results. Set in WHERE clause."},
@@ -103,16 +100,14 @@ func tableFleetdmSoftwareTitle(ctx context.Context) *plugin.Table {
 }
 
 func listSoftwareTitles(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	client, err := NewFleetDMClient(ctx, d.Connection)
+	client, err := getClient(ctx, d)
 	if err != nil {
 		plugin.Logger(ctx).Error("fleetdm_software_title.listSoftwareTitles", "connection_error", err)
 		return nil, err
 	}
 
-	page := 0
-	perPage := 10000
-
-	for {
+	// Bulk endpoint: large pages keep the page count low on big inventories.
+	err = paginatedList(ctx, d, 1000, func(ctx context.Context, page, perPage int) ([]SoftwareTitle, *ListMeta, error) {
 		params := url.Values{}
 		params.Add("page", strconv.Itoa(page))
 		params.Add("per_page", strconv.Itoa(perPage))
@@ -146,10 +141,10 @@ func listSoftwareTitles(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 		}
 
 		if d.EqualsQuals["min_cvss_score"] != nil {
-			params.Add("min_cvss_score", strconv.FormatInt(d.EqualsQuals["min_cvss_score"].GetInt64Value(), 10))
+			params.Add("min_cvss_score", strconv.FormatFloat(d.EqualsQuals["min_cvss_score"].GetDoubleValue(), 'f', -1, 64))
 		}
 		if d.EqualsQuals["max_cvss_score"] != nil {
-			params.Add("max_cvss_score", strconv.FormatInt(d.EqualsQuals["max_cvss_score"].GetInt64Value(), 10))
+			params.Add("max_cvss_score", strconv.FormatFloat(d.EqualsQuals["max_cvss_score"].GetDoubleValue(), 'f', -1, 64))
 		}
 		if d.EqualsQuals["exploit"] != nil {
 			params.Add("exploit", strconv.FormatBool(d.EqualsQuals["exploit"].GetBoolValue()))
@@ -162,40 +157,15 @@ func listSoftwareTitles(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 		}
 
 		var response ListSoftwareTitlesResponse
-		_, err := client.Get(ctx, "software/titles", params, &response) // Endpoint is /api/v1/fleet/software/titles
-		if err != nil {
+		if err := client.Get(ctx, "software/titles", params, &response); err != nil {
 			plugin.Logger(ctx).Error("fleetdm_software_title.listSoftwareTitles", "api_error", err, "page", page, "params", params.Encode())
-			return nil, err
+			return nil, nil, err
 		}
-
-		for _, title := range response.SoftwareTitles {
-			d.StreamListItem(ctx, title)
-			if d.RowsRemaining(ctx) == 0 {
-				plugin.Logger(ctx).Debug("fleetdm_software_title.listSoftwareTitles", "limit_reached_sdk", "true")
-				return nil, nil
-			}
-		}
-
-		plugin.Logger(ctx).Info("fleetdm_software_title.listSoftwareTitles",
-			"page_processed", page,
-			"items_on_page", len(response.SoftwareTitles),
-			"api_total_count", response.Count,
-			"api_has_next_results", response.Meta.HasNextResults,
-		)
-
-		if len(response.SoftwareTitles) < perPage {
-			plugin.Logger(ctx).Info("fleetdm_software_title.listSoftwareTitles", "pagination_ended_item_count_less_than_per_page", true, "current_page", page, "items_on_page", len(response.SoftwareTitles), "per_page", perPage)
-			break
-		}
-
-		if !response.Meta.HasNextResults && len(response.SoftwareTitles) == perPage {
-			plugin.Logger(ctx).Warn("fleetdm_software_title.listSoftwareTitles", "api_has_next_results_is_false_but_full_page_received", true, "current_page", page)
-		}
-
-		page++
-		plugin.Logger(ctx).Debug("fleetdm_software_title.listSoftwareTitles", "incrementing_to_next_page", page)
+		return response.SoftwareTitles, response.Meta, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
-	plugin.Logger(ctx).Info("fleetdm_software_title.listSoftwareTitles", "list_software_titles_completed", true)
 	return nil, nil
 }

--- a/fleetdm/table_fleetdm_software_version.go
+++ b/fleetdm/table_fleetdm_software_version.go
@@ -79,12 +79,8 @@ type Software struct {
 // ListSoftwareResponse is the expected structure for the list software API call.
 type ListSoftwareResponse struct {
 	Software []Software `json:"software"`
-	Meta     struct {
-		HasNextResults     bool   `json:"has_next_results"`
-		HasPreviousResults bool   `json:"has_previous_results"`
-		NextCursor         string `json:"next_cursor"`
-	} `json:"meta"`
-	Count int `json:"count"` // Total count of all software items matching the query
+	Meta     *ListMeta  `json:"meta"`
+	Count    int        `json:"count"` // Total count of all software items matching the query
 }
 
 func tableFleetdmSoftwareVersion(ctx context.Context) *plugin.Table {
@@ -129,25 +125,22 @@ func tableFleetdmSoftwareVersion(ctx context.Context) *plugin.Table {
 			{Name: "vulnerable_only", Type: proto.ColumnType_BOOL, Transform: transform.FromQual("vulnerable_only"), Description: "Filter for software with known vulnerabilities. Set in WHERE clause."},
 			{Name: "team_id", Type: proto.ColumnType_INT, Transform: transform.FromQual("team_id"), Description: "Filter by team ID (Fleet Premium). Use 0 for hosts assigned to 'No team'. Set in WHERE clause."},
 			{Name: "query", Type: proto.ColumnType_STRING, Transform: transform.FromQual("query"), Description: "Search query keywords. Searchable fields include name, version, and CVE. Set in WHERE clause."},
-			{Name: "min_cvss_score", Type: proto.ColumnType_INT, Transform: transform.FromQual("min_cvss_score"), Description: "Filter for software with vulnerabilities having a CVSS v3.x base score higher than this value (Fleet Premium). Set in WHERE clause."},
-			{Name: "max_cvss_score", Type: proto.ColumnType_INT, Transform: transform.FromQual("max_cvss_score"), Description: "Filter for software with vulnerabilities having a CVSS v3.x base score lower than this value (Fleet Premium). Set in WHERE clause."},
+			{Name: "min_cvss_score", Type: proto.ColumnType_DOUBLE, Transform: transform.FromQual("min_cvss_score"), Description: "Filter for software with vulnerabilities having a CVSS v3.x base score higher than this value (Fleet Premium). Set in WHERE clause."},
+			{Name: "max_cvss_score", Type: proto.ColumnType_DOUBLE, Transform: transform.FromQual("max_cvss_score"), Description: "Filter for software with vulnerabilities having a CVSS v3.x base score lower than this value (Fleet Premium). Set in WHERE clause."},
 			{Name: "exploit", Type: proto.ColumnType_BOOL, Transform: transform.FromQual("exploit"), Description: "Filter for software with vulnerabilities that have been actively exploited in the wild — CISA known exploit (Fleet Premium). Set in WHERE clause."},
 		},
 	}
 }
 
 func listSoftwareVersions(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	client, err := NewFleetDMClient(ctx, d.Connection)
+	client, err := getClient(ctx, d)
 	if err != nil {
 		plugin.Logger(ctx).Error("fleetdm_software_version.listSoftwareVersions", "connection_error", err)
 		return nil, err
 	}
 
-	page := 0
-	// perPage is the number of items to request per API call.
-	perPage := 10000 // This seems to have no limit and 100 was making it super slow, 1000 slow so let's go with 10000 🤠.
-
-	for {
+	// Bulk endpoint: large pages keep the page count low on big inventories.
+	err = paginatedList(ctx, d, 1000, func(ctx context.Context, page, perPage int) ([]Software, *ListMeta, error) {
 		params := url.Values{}
 		params.Add("page", strconv.Itoa(page))
 		params.Add("per_page", strconv.Itoa(perPage))
@@ -172,66 +165,25 @@ func listSoftwareVersions(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 		}
 
 		if d.EqualsQuals["min_cvss_score"] != nil {
-			params.Add("min_cvss_score", strconv.FormatInt(d.EqualsQuals["min_cvss_score"].GetInt64Value(), 10))
+			params.Add("min_cvss_score", strconv.FormatFloat(d.EqualsQuals["min_cvss_score"].GetDoubleValue(), 'f', -1, 64))
 		}
 		if d.EqualsQuals["max_cvss_score"] != nil {
-			params.Add("max_cvss_score", strconv.FormatInt(d.EqualsQuals["max_cvss_score"].GetInt64Value(), 10))
+			params.Add("max_cvss_score", strconv.FormatFloat(d.EqualsQuals["max_cvss_score"].GetDoubleValue(), 'f', -1, 64))
 		}
 		if d.EqualsQuals["exploit"] != nil {
 			params.Add("exploit", strconv.FormatBool(d.EqualsQuals["exploit"].GetBoolValue()))
 		}
 
 		var response ListSoftwareResponse
-		_, err := client.Get(ctx, "software/versions", params, &response) // Endpoint is /api/v1/fleet/software/versions
-		if err != nil {
+		if err := client.Get(ctx, "software/versions", params, &response); err != nil {
 			plugin.Logger(ctx).Error("fleetdm_software_version.listSoftwareVersions", "api_error", err, "page", page, "params", params.Encode())
-			return nil, err
+			return nil, nil, err
 		}
-
-		for _, swItem := range response.Software {
-			d.StreamListItem(ctx, swItem)
-			if d.RowsRemaining(ctx) == 0 {
-				plugin.Logger(ctx).Debug("fleetdm_software_version.listSoftwareVersions", "limit_reached_sdk", "true")
-				return nil, nil
-			}
-		}
-
-		// Log pagination details from the API response
-		plugin.Logger(ctx).Info("fleetdm_software_version.listSoftwareVersions",
-			"page_processed", page,
-			"items_on_page", len(response.Software),
-			"api_total_count", response.Count, // Total items matching filter, not just on this page
-			"api_has_next_results", response.Meta.HasNextResults,
-			"api_next_cursor", response.Meta.NextCursor,
-		)
-
-		// Determine if there are more pages to fetch.
-		// Primary condition: Continue if the API returned a full page of items.
-		if len(response.Software) < perPage {
-			plugin.Logger(ctx).Info("fleetdm_software_version.listSoftwareVersions", "pagination_ended_item_count_less_than_per_page", true, "current_page", page, "items_on_page", len(response.Software), "per_page", perPage)
-			break
-		}
-
-		// Secondary check (optional, but good for observation): Log if HasNextResults is false but we got a full page.
-		// This might indicate an inconsistency in the API's meta field.
-		if !response.Meta.HasNextResults && len(response.Software) == perPage {
-			plugin.Logger(ctx).Warn("fleetdm_software_version.listSoftwareVersions", "api_has_next_results_is_false_but_full_page_received", true, "current_page", page)
-			// Depending on API behavior, you might still want to try fetching the next page,
-			// or trust len(response.Software) < perPage as the more reliable indicator.
-			// For now, we will break if len(response.Software) < perPage, making HasNextResults secondary.
-		}
-
-		// If HasNextResults is explicitly false, and we trust it, we can break early.
-		// However, considering a previous issue existed, let's prioritize the item count.
-		// if !response.Meta.HasNextResults {
-		// 	plugin.Logger(ctx).Info("fleetdm_software_version.listSoftwareVersions", "pagination_ended_by_api_has_next_results_false", true, "current_page", page)
-		// 	break
-		// }
-
-		page++
-		plugin.Logger(ctx).Debug("fleetdm_software_version.listSoftwareVersions", "incrementing_to_next_page", page)
+		return response.Software, response.Meta, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
-	plugin.Logger(ctx).Info("fleetdm_software_version.listSoftwareVersions", "list_software_versions_completed", true)
 	return nil, nil
 }

--- a/fleetdm/table_fleetdm_team.go
+++ b/fleetdm/table_fleetdm_team.go
@@ -109,22 +109,13 @@ func getTeamSecrets(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateD
 }
 
 func listTeams(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	client, err := NewFleetDMClient(ctx, d.Connection)
+	client, err := getClient(ctx, d)
 	if err != nil {
 		plugin.Logger(ctx).Error("fleetdm_team.listTeams", "connection_error", err)
 		return nil, err
 	}
 
-	// Pagination for teams: The /api/v1/fleet/teams endpoint supports `page` and `per_page`
-	page := 0
-	perPage := 10000
-
-	// limit := d.QueryContext.Limit
-	// if limit != nil && *limit < int64(perPage) {
-	// 	// perPage = int(*limit)
-	// }
-
-	for {
+	err = paginatedList(ctx, d, 100, func(ctx context.Context, page, perPage int) ([]Team, *ListMeta, error) {
 		params := url.Values{}
 		params.Add("page", strconv.Itoa(page))
 		params.Add("per_page", strconv.Itoa(perPage))
@@ -134,42 +125,17 @@ func listTeams(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) 
 		}
 
 		var response ListTeamsResponse
-		_, err := client.Get(ctx, "teams", params, &response)
-		if err != nil {
+		if err := client.Get(ctx, "teams", params, &response); err != nil {
 			plugin.Logger(ctx).Error("fleetdm_team.listTeams", "api_error", err, "page", page)
-			return nil, err
+			return nil, nil, err
 		}
-
-		for _, team := range response.Teams {
-			// The list endpoint for teams might not include all details like full user list or secrets.
-			// These are typically available in the "Get team" endpoint.
-			// We can stream the basic info here, and rely on GetTeam or a separate hydrate for richer details if needed.
-			// For now, we assume the list endpoint provides sufficient top-level info.
-			// The `users` field in the `Team` struct will be populated by `getTeam` when a single team is fetched.
-			// For `listTeams`, the `users` field might be empty or contain minimal info from the list endpoint.
-			// The API doc for "List teams" does not show `users` or `secrets` in the response items.
-			// These are shown in "Get team". So, for list, these fields will be nil/empty.
-			// We can add a hydrate function to populate them if `plugin.GetConfig` is not used.
-			// Or, document that these fields are primarily for `Get`.
-			// For simplicity in list, we stream what `GET /teams` provides.
-			// The `users` column in the table definition will be hydrated by `getTeam` for individual `GET`s.
-			// If we want `users` for `LIST`, we'd need a separate hydrate call for each team.
-			d.StreamListItem(ctx, team)
-			if d.RowsRemaining(ctx) == 0 {
-				plugin.Logger(ctx).Debug("fleetdm_team.listTeams", "limit_reached", true)
-				return nil, nil
-			}
-		}
-
-		// Pagination check: if the number of teams returned is less than per_page,
-		// it's the last page. The `/teams` endpoint does not specify a `meta.has_next_results`.
-		if len(response.Teams) < perPage {
-			plugin.Logger(ctx).Debug("fleetdm_team.listTeams", "end_of_results", true, "teams_on_page", len(response.Teams))
-			break
-		}
-
-		page++
-		plugin.Logger(ctx).Debug("fleetdm_team.listTeams", "next_page", page)
+		// The /teams endpoint does not document a meta object for pagination.
+		// The list endpoint provides top-level team info only; `users` and
+		// `secrets` are populated by the "Get team" endpoint.
+		return response.Teams, nil, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return nil, nil

--- a/fleetdm/table_fleetdm_user.go
+++ b/fleetdm/table_fleetdm_user.go
@@ -72,22 +72,13 @@ func tableFleetdmUser(ctx context.Context) *plugin.Table {
 }
 
 func listUsers(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	client, err := NewFleetDMClient(ctx, d.Connection)
+	client, err := getClient(ctx, d)
 	if err != nil {
 		plugin.Logger(ctx).Error("fleetdm_user.listUsers", "connection_error", err)
 		return nil, err
 	}
 
-	// Pagination for users: The /api/v1/fleet/users endpoint supports `page` and `per_page`
-	page := 0
-	perPage := 50 // A reasonable default, adjust as needed or if API has specific limits/max
-
-	// limit := d.QueryContext.Limit
-	// if limit != nil && *limit < int64(perPage) {
-	// 	// perPage = int(*limit) // Be cautious if API has minimum per_page
-	// }
-
-	for {
+	err = paginatedList(ctx, d, 100, func(ctx context.Context, page, perPage int) ([]User, *ListMeta, error) {
 		params := url.Values{}
 		params.Add("page", strconv.Itoa(page))
 		params.Add("per_page", strconv.Itoa(perPage))
@@ -100,45 +91,15 @@ func listUsers(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) 
 		}
 
 		var usersResponse ListUsersResponse
-
-		httpResp, err := client.Get(ctx, "users", params, &usersResponse) // Pass ListUsersResponse struct
-		if err != nil {
+		if err := client.Get(ctx, "users", params, &usersResponse); err != nil {
 			plugin.Logger(ctx).Error("fleetdm_user.listUsers", "api_error", err, "page", page)
-			return nil, err
+			return nil, nil, err
 		}
-
-		// Check if usersResponse.Users is nil after a successful HTTP call, which might indicate an empty list or unexpected response format
-		if httpResp.StatusCode == 200 && usersResponse.Users == nil {
-			// This could happen if the API returned `[]` instead of `{"users": []}` and the decoder didn't error but also didn't populate.
-			// Or if it returned `{"users": null}`.
-			// Given the API docs, `{"users": [...]}` is expected, so `usersResponse.Users` should be populated.
-			// If it's nil, it implies an empty list of users from the API for this page.
-			plugin.Logger(ctx).Debug("fleetdm_user.listUsers", "users_array_is_nil_or_empty_on_page", page)
-			// This is a valid state for the last page if it's empty, or if there are no users.
-		}
-
-		if len(usersResponse.Users) == 0 && page == 0 { // No users found at all on the first page
-			plugin.Logger(ctx).Debug("fleetdm_user.listUsers", "no_users_found_at_all", true)
-			return nil, nil // Stop if no users on the very first call
-		}
-
-		for _, user := range usersResponse.Users {
-			d.StreamListItem(ctx, user)
-			if d.RowsRemaining(ctx) == 0 {
-				plugin.Logger(ctx).Debug("fleetdm_user.listUsers", "limit_reached", true)
-				return nil, nil
-			}
-		}
-
-		// Pagination check: if the number of users returned is less than per_page,
-		// it's the last page. FleetDM's /users endpoint does not seem to use a 'meta.has_next_results' field.
-		if len(usersResponse.Users) < perPage {
-			plugin.Logger(ctx).Debug("fleetdm_user.listUsers", "end_of_results", true, "users_on_page", len(usersResponse.Users))
-			break
-		}
-
-		page++
-		plugin.Logger(ctx).Debug("fleetdm_user.listUsers", "next_page", page)
+		// The /users endpoint does not document a meta object for pagination.
+		return usersResponse.Users, nil, nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return nil, nil

--- a/fleetdm/utils.go
+++ b/fleetdm/utils.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os" // Added for os.Getenv
+	"strconv"
 	"strings"
 	"time"
 
@@ -77,6 +78,30 @@ type FleetDMClient struct {
 	BaseURL    string
 	APIToken   string
 	HTTPClient *http.Client
+}
+
+// defaultRequestTimeout is used when request_timeout is not set in the config.
+const defaultRequestTimeout = 30 * time.Second
+
+// getClient returns the FleetDMClient for this connection, building it once
+// and memoizing it in the connection cache. This avoids re-parsing the config
+// and re-allocating an http.Client per list call / per hydrate row.
+func getClient(ctx context.Context, d *plugin.QueryData) (*FleetDMClient, error) {
+	const cacheKey = "fleetdm_client"
+	if v, ok := d.ConnectionCache.Get(ctx, cacheKey); ok {
+		if c, ok := v.(*FleetDMClient); ok {
+			return c, nil
+		}
+	}
+	c, err := NewFleetDMClient(ctx, d.Connection)
+	if err != nil {
+		return nil, err
+	}
+	// The SDK applies its own TTL; a rebuild after expiry is cheap.
+	if err := d.ConnectionCache.Set(ctx, cacheKey, c); err != nil {
+		plugin.Logger(ctx).Warn("getClient", "connection_cache_set_error", err)
+	}
+	return c, nil
 }
 
 // NewFleetDMClient creates a new FleetDM API client.
@@ -153,11 +178,19 @@ func NewFleetDMClient(ctx context.Context, connection *plugin.Connection) (*Flee
 
 	plugin.Logger(ctx).Debug("NewFleetDMClient", "final_derived_base_url", baseURL)
 
+	timeout := defaultRequestTimeout
+	if config.RequestTimeout != nil {
+		if *config.RequestTimeout <= 0 {
+			return nil, fmt.Errorf("request_timeout must be a positive number of seconds, got %d", *config.RequestTimeout)
+		}
+		timeout = time.Duration(*config.RequestTimeout) * time.Second
+	}
+
 	return &FleetDMClient{
 		BaseURL:  baseURL,
 		APIToken: apiToken,
 		HTTPClient: &http.Client{
-			Timeout: 30 * time.Second,
+			Timeout: timeout,
 		},
 	}, nil
 }
@@ -172,9 +205,65 @@ func truncateBody(b []byte, n int) string {
 	return string(b[:n]) + "… (truncated)"
 }
 
-// Get performs a GET request to the specified FleetDM API endpoint.
-// The response is unmarshalled into the `target` interface.
-func (c *FleetDMClient) Get(ctx context.Context, endpoint string, queryParams url.Values, target interface{}) (*http.Response, error) {
+// FleetAPIError is returned for non-2xx API responses. It carries the HTTP
+// status code so retry/ignore predicates can classify failures without string
+// matching.
+type FleetAPIError struct {
+	StatusCode int
+	Status     string
+	URL        string
+	Snippet    string        // truncated response body, safe for SQL clients
+	RetryAfter time.Duration // parsed from the Retry-After header, 0 if absent
+}
+
+func (e *FleetAPIError) Error() string {
+	if e.Snippet == "" {
+		return fmt.Sprintf("API request to %s failed with status %s", e.URL, e.Status)
+	}
+	return fmt.Sprintf("API request to %s failed with status %s: %s", e.URL, e.Status, e.Snippet)
+}
+
+// parseRetryAfter parses a Retry-After header value (delay-seconds or HTTP-date).
+func parseRetryAfter(v string) time.Duration {
+	if v == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
+		return time.Duration(secs) * time.Second
+	}
+	if t, err := http.ParseTime(v); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d
+		}
+	}
+	return 0
+}
+
+// maxRetryAfterSleep caps how long Get will honor a server's Retry-After
+// in-line before handing the error to the SDK retry machinery.
+const maxRetryAfterSleep = 10 * time.Second
+
+// shouldRetryError tells the SDK retry machinery to retry rate limits and
+// transient server errors.
+func shouldRetryError(_ context.Context, _ *plugin.QueryData, _ *plugin.HydrateData, err error) bool {
+	var apiErr *FleetAPIError
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode == http.StatusTooManyRequests || apiErr.StatusCode >= 500
+	}
+	return false
+}
+
+// shouldIgnoreError maps 404s to "no rows" instead of a query error, so
+// get-by-id lookups for deleted resources behave like SQL misses.
+func shouldIgnoreError(_ context.Context, _ *plugin.QueryData, _ *plugin.HydrateData, err error) bool {
+	var apiErr *FleetAPIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound
+}
+
+// Get performs a GET request to the specified FleetDM API endpoint and
+// unmarshals the response into target (which may be nil to discard the body).
+// Non-2xx responses are returned as *FleetAPIError.
+func (c *FleetDMClient) Get(ctx context.Context, endpoint string, queryParams url.Values, target interface{}) error {
 	// Construct the full URL
 	// Ensure endpoint doesn't start with a slash if BaseURL already ends with one
 	trimmedEndpoint := strings.TrimPrefix(endpoint, "/")
@@ -183,7 +272,7 @@ func (c *FleetDMClient) Get(ctx context.Context, endpoint string, queryParams ur
 	fullURL, err := url.Parse(fullURLString)
 	if err != nil {
 		plugin.Logger(ctx).Error("FleetDMClient.Get", "url_parse_error", err, "base_url", c.BaseURL, "endpoint", endpoint)
-		return nil, fmt.Errorf("error parsing base URL '%s' and endpoint '%s': %w", c.BaseURL, endpoint, err)
+		return fmt.Errorf("error parsing base URL '%s' and endpoint '%s': %w", c.BaseURL, endpoint, err)
 	}
 	if queryParams != nil {
 		fullURL.RawQuery = queryParams.Encode()
@@ -195,18 +284,19 @@ func (c *FleetDMClient) Get(ctx context.Context, endpoint string, queryParams ur
 	req, err := http.NewRequestWithContext(ctx, "GET", fullURL.String(), nil)
 	if err != nil {
 		plugin.Logger(ctx).Error("FleetDMClient.Get", "request_creation_error", err, "url", fullURL.String())
-		return nil, fmt.Errorf("error creating HTTP request for %s: %w", fullURL.String(), err)
+		return fmt.Errorf("error creating HTTP request for %s: %w", fullURL.String(), err)
 	}
 
 	// Set headers
 	req.Header.Set("Authorization", "Bearer "+c.APIToken)
 	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "steampipe-plugin-fleetdm/"+pluginVersion)
 
 	// Perform the request
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
 		plugin.Logger(ctx).Error("FleetDMClient.Get", "http_do_error", err, "url", fullURL.String())
-		return resp, fmt.Errorf("error performing HTTP request to %s: %w", fullURL.String(), err)
+		return fmt.Errorf("error performing HTTP request to %s: %w", fullURL.String(), err)
 	}
 	defer func() {
 		if cerr := resp.Body.Close(); cerr != nil {
@@ -216,13 +306,30 @@ func (c *FleetDMClient) Get(ctx context.Context, endpoint string, queryParams ur
 
 	// Check for non-2xx status codes
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		apiErr := &FleetAPIError{
+			StatusCode: resp.StatusCode,
+			Status:     resp.Status,
+			URL:        fullURL.String(),
+			RetryAfter: parseRetryAfter(resp.Header.Get("Retry-After")),
+		}
 		bodyBytes, readErr := io.ReadAll(resp.Body)
 		if readErr != nil {
 			plugin.Logger(ctx).Error("FleetDMClient.Get", "read_error_body_failed", readErr, "url", fullURL.String(), "status_code", resp.StatusCode)
-			return resp, fmt.Errorf("API request to %s failed with status %s (unable to read error body)", fullURL.String(), resp.Status)
+		} else {
+			plugin.Logger(ctx).Error("FleetDMClient.Get", "api_error_response", string(bodyBytes), "url", fullURL.String(), "status_code", resp.StatusCode)
+			apiErr.Snippet = truncateBody(bodyBytes, 200)
 		}
-		plugin.Logger(ctx).Error("FleetDMClient.Get", "api_error_response", string(bodyBytes), "url", fullURL.String(), "status_code", resp.StatusCode)
-		return resp, fmt.Errorf("API request to %s failed with status %s: %s", fullURL.String(), resp.Status, truncateBody(bodyBytes, 200))
+
+		// Honor Retry-After in-line (bounded, context-aware) so the SDK's
+		// exponential backoff retries against a server that is ready again.
+		if apiErr.RetryAfter > 0 && (resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusServiceUnavailable) {
+			sleep := min(apiErr.RetryAfter, maxRetryAfterSleep)
+			select {
+			case <-ctx.Done():
+			case <-time.After(sleep):
+			}
+		}
+		return apiErr
 	}
 
 	// Decode the JSON response
@@ -230,14 +337,75 @@ func (c *FleetDMClient) Get(ctx context.Context, endpoint string, queryParams ur
 		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			plugin.Logger(ctx).Error("FleetDMClient.Get", "read_body_for_decode_error", err, "url", fullURL.String())
-			return resp, fmt.Errorf("error reading response body from %s: %w", fullURL.String(), err)
+			return fmt.Errorf("error reading response body from %s: %w", fullURL.String(), err)
 		}
 
 		if err := json.Unmarshal(bodyBytes, target); err != nil {
 			plugin.Logger(ctx).Error("FleetDMClient.Get", "json_decode_error", err, "url", fullURL.String(), "response_body_snippet", truncateBody(bodyBytes, 500))
-			return resp, fmt.Errorf("error decoding JSON response from %s: %w. Response body: %s", fullURL.String(), err, truncateBody(bodyBytes, 200))
+			return fmt.Errorf("error decoding JSON response from %s: %w. Response body: %s", fullURL.String(), err, truncateBody(bodyBytes, 200))
 		}
 	}
 
-	return resp, nil
+	return nil
+}
+
+// ListMeta mirrors FleetDM's pagination meta object. Response envelopes embed
+// it as a *pointer* so "meta absent from the response" (nil) is
+// distinguishable from has_next_results=false.
+type ListMeta struct {
+	HasNextResults     bool `json:"has_next_results"`
+	HasPreviousResults bool `json:"has_previous_results"`
+}
+
+// fetchPageFunc fetches one page of results. It returns the page's items and
+// the response meta object (nil when the endpoint has no meta object).
+type fetchPageFunc[T any] func(ctx context.Context, page, perPage int) (items []T, meta *ListMeta, err error)
+
+// forEachItem is invoked per item; returning false stops pagination early
+// (e.g. the query's LIMIT was reached).
+type forEachItem[T any] func(item T) bool
+
+// paginateCore drives page/per_page iteration. Termination rules:
+//  1. an empty page always terminates (no data progress);
+//  2. when the response has a meta object, meta.has_next_results is
+//     authoritative;
+//  3. otherwise keep fetching until an empty page.
+//
+// Deliberately NOT a rule: stopping when len(items) < perPage. Servers may
+// clamp per_page, which would silently truncate results.
+func paginateCore[T any](ctx context.Context, perPage int, fetch fetchPageFunc[T], each forEachItem[T]) error {
+	for page := 0; ; page++ {
+		items, meta, err := fetch(ctx, page, perPage)
+		if err != nil {
+			return err
+		}
+		for _, item := range items {
+			if !each(item) {
+				return nil
+			}
+		}
+		if len(items) == 0 {
+			if meta != nil && meta.HasNextResults {
+				plugin.Logger(ctx).Warn("paginateCore", "empty_page_with_has_next_results", true, "page", page)
+			}
+			return nil
+		}
+		if meta != nil && !meta.HasNextResults {
+			return nil
+		}
+	}
+}
+
+// paginatedList is the Steampipe shim over paginateCore used by table list
+// functions: it sizes per_page from the query's LIMIT when smaller, streams
+// every item, and stops as soon as the SDK reports no rows remaining.
+func paginatedList[T any](ctx context.Context, d *plugin.QueryData, defaultPerPage int, fetch fetchPageFunc[T]) error {
+	perPage := defaultPerPage
+	if limit := d.QueryContext.Limit; limit != nil && *limit > 0 && *limit < int64(perPage) {
+		perPage = int(*limit)
+	}
+	return paginateCore(ctx, perPage, fetch, func(item T) bool {
+		d.StreamListItem(ctx, item)
+		return d.RowsRemaining(ctx) > 0
+	})
 }

--- a/fleetdm/utils_test.go
+++ b/fleetdm/utils_test.go
@@ -1,0 +1,387 @@
+package fleetdm
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/context_key"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+// ptr returns a pointer to v; a tiny helper for building config literals.
+func ptr[T any](v T) *T { return &v }
+
+// testCtx returns a context carrying a null hclog logger, since
+// plugin.Logger(ctx) type-asserts the context value and panics on a bare
+// context.
+func testCtx(t *testing.T) context.Context {
+	t.Helper()
+	return context.WithValue(context.Background(), context_key.Logger, hclog.NewNullLogger())
+}
+
+// testConnection builds a *plugin.Connection with the given config values.
+func testConnection(serverURL, apiToken *string, requestTimeout *int) *plugin.Connection {
+	return &plugin.Connection{
+		Name: "test",
+		Config: fleetdmConfig{
+			ServerURL:      serverURL,
+			APIToken:       apiToken,
+			RequestTimeout: requestTimeout,
+		},
+	}
+}
+
+func TestFleetTimeUnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		wantZero bool
+		want     time.Time
+		wantErr  bool
+	}{
+		{name: "null literal", input: `null`, wantZero: true},
+		{name: "empty string", input: `""`, wantZero: true},
+		{
+			name:  "valid RFC3339",
+			input: `"2026-01-02T15:04:05Z"`,
+			want:  time.Date(2026, 1, 2, 15, 4, 5, 0, time.UTC),
+		},
+		{name: "garbage", input: `"not-a-time"`, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var ft FleetTime
+			err := ft.UnmarshalJSON([]byte(tc.input))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("UnmarshalJSON(%s) = nil error, want error", tc.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("UnmarshalJSON(%s) unexpected error: %v", tc.input, err)
+			}
+			if tc.wantZero {
+				if !ft.IsZero() {
+					t.Fatalf("UnmarshalJSON(%s) = %v, want zero time", tc.input, ft.Time)
+				}
+				return
+			}
+			if !ft.Equal(tc.want) {
+				t.Fatalf("UnmarshalJSON(%s) = %v, want %v", tc.input, ft.Time, tc.want)
+			}
+		})
+	}
+}
+
+func TestFleetTimeMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	zero, err := FleetTime{}.MarshalJSON()
+	if err != nil {
+		t.Fatalf("MarshalJSON(zero) unexpected error: %v", err)
+	}
+	if string(zero) != "null" {
+		t.Errorf("MarshalJSON(zero) = %s, want null", zero)
+	}
+
+	ft := FleetTime{Time: time.Date(2026, 1, 2, 15, 4, 5, 0, time.UTC)}
+	got, err := ft.MarshalJSON()
+	if err != nil {
+		t.Fatalf("MarshalJSON(non-zero) unexpected error: %v", err)
+	}
+	if string(got) != `"2026-01-02T15:04:05Z"` {
+		t.Errorf("MarshalJSON(non-zero) = %s, want %q", got, `"2026-01-02T15:04:05Z"`)
+	}
+}
+
+func TestFlexibleTimeTransform(t *testing.T) {
+	t.Parallel()
+
+	when := time.Date(2026, 1, 2, 15, 4, 5, 0, time.UTC)
+
+	tests := []struct {
+		name    string
+		value   interface{}
+		want    interface{}
+		wantErr bool
+	}{
+		{name: "nil value", value: nil, want: nil},
+		{name: "FleetTime zero", value: FleetTime{}, want: nil},
+		{name: "FleetTime non-zero", value: FleetTime{Time: when}, want: when},
+		{name: "*FleetTime nil", value: (*FleetTime)(nil), want: nil},
+		{name: "*FleetTime zero", value: &FleetTime{}, want: nil},
+		{name: "*FleetTime non-zero", value: &FleetTime{Time: when}, want: when},
+		{name: "time.Time zero", value: time.Time{}, want: nil},
+		{name: "time.Time non-zero", value: when, want: when},
+		{name: "*time.Time nil", value: (*time.Time)(nil), want: nil},
+		{name: "*time.Time non-zero", value: &when, want: when},
+		{name: "unexpected type", value: 42, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := flexibleTimeTransform(context.Background(), &transform.TransformData{Value: tc.value})
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("flexibleTimeTransform(%#v) = nil error, want error", tc.value)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("flexibleTimeTransform(%#v) unexpected error: %v", tc.value, err)
+			}
+			if tc.want == nil {
+				if got != nil {
+					t.Fatalf("flexibleTimeTransform(%#v) = %v, want nil", tc.value, got)
+				}
+				return
+			}
+			gotTime, ok := got.(time.Time)
+			if !ok {
+				t.Fatalf("flexibleTimeTransform(%#v) returned %T, want time.Time", tc.value, got)
+			}
+			if !gotTime.Equal(tc.want.(time.Time)) {
+				t.Fatalf("flexibleTimeTransform(%#v) = %v, want %v", tc.value, gotTime, tc.want)
+			}
+		})
+	}
+}
+
+func TestTruncateBody(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		n     int
+		want  string
+	}{
+		{name: "shorter than n", input: "short", n: 10, want: "short"},
+		{name: "exactly n", input: "0123456789", n: 10, want: "0123456789"},
+		{name: "longer than n", input: "0123456789X", n: 10, want: "0123456789… (truncated)"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := truncateBody([]byte(tc.input), tc.n); got != tc.want {
+				t.Errorf("truncateBody(%q, %d) = %q, want %q", tc.input, tc.n, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  time.Duration
+	}{
+		{name: "empty", input: "", want: 0},
+		{name: "delay seconds", input: "5", want: 5 * time.Second},
+		{name: "zero seconds", input: "0", want: 0},
+		{name: "negative seconds", input: "-3", want: 0},
+		{name: "past HTTP-date", input: time.Now().Add(-30 * time.Second).UTC().Format(http.TimeFormat), want: 0},
+		{name: "garbage", input: "not-a-duration", want: 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := parseRetryAfter(tc.input); got != tc.want {
+				t.Errorf("parseRetryAfter(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+
+	t.Run("future HTTP-date", func(t *testing.T) {
+		t.Parallel()
+		v := time.Now().Add(30 * time.Second).UTC().Format(http.TimeFormat)
+		got := parseRetryAfter(v)
+		if got <= 0 || got > 31*time.Second {
+			t.Errorf("parseRetryAfter(%q) = %v, want a positive duration of at most ~30s", v, got)
+		}
+	})
+}
+
+func TestNewFleetDMClientURLNormalization(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		serverURL  string
+		wantBase   string
+		wantErrSub string // non-empty means an error containing this substring is expected
+	}{
+		{
+			name:      "bare https host",
+			serverURL: "https://fleet.example.com",
+			wantBase:  "https://fleet.example.com/api/v1/fleet/",
+		},
+		{
+			name:      "trailing slash",
+			serverURL: "https://fleet.example.com/",
+			wantBase:  "https://fleet.example.com/api/v1/fleet/",
+		},
+		{
+			name:      "api suffix",
+			serverURL: "https://fleet.example.com/api",
+			wantBase:  "https://fleet.example.com/api/v1/fleet/",
+		},
+		{
+			name:      "api/v1 suffix",
+			serverURL: "https://fleet.example.com/api/v1",
+			wantBase:  "https://fleet.example.com/api/v1/fleet/",
+		},
+		{
+			name:      "api/v1/fleet suffix",
+			serverURL: "https://fleet.example.com/api/v1/fleet",
+			wantBase:  "https://fleet.example.com/api/v1/fleet/",
+		},
+		{
+			name:      "http localhost allowed",
+			serverURL: "http://localhost:8080",
+			wantBase:  "http://localhost:8080/api/v1/fleet/",
+		},
+		{
+			name:      "http loopback IP allowed",
+			serverURL: "http://127.0.0.1:8080",
+			wantBase:  "http://127.0.0.1:8080/api/v1/fleet/",
+		},
+		{
+			name:       "http non-loopback rejected",
+			serverURL:  "http://fleet.example.com",
+			wantErrSub: "cleartext",
+		},
+		{
+			name:       "unsupported scheme",
+			serverURL:  "ftp://x",
+			wantErrSub: "unsupported scheme",
+		},
+		{
+			name:       "missing scheme",
+			serverURL:  "fleet.example.com",
+			wantErrSub: "absolute URL",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			conn := testConnection(ptr(tc.serverURL), ptr("t"), nil)
+			client, err := NewFleetDMClient(testCtx(t), conn)
+			if tc.wantErrSub != "" {
+				if err == nil {
+					t.Fatalf("NewFleetDMClient(%q) = nil error, want error containing %q", tc.serverURL, tc.wantErrSub)
+				}
+				if !strings.Contains(err.Error(), tc.wantErrSub) {
+					t.Fatalf("NewFleetDMClient(%q) error = %q, want it to contain %q", tc.serverURL, err, tc.wantErrSub)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewFleetDMClient(%q) unexpected error: %v", tc.serverURL, err)
+			}
+			if client.BaseURL != tc.wantBase {
+				t.Errorf("NewFleetDMClient(%q) BaseURL = %q, want %q", tc.serverURL, client.BaseURL, tc.wantBase)
+			}
+		})
+	}
+}
+
+// Env-dependent cases use t.Setenv, which is incompatible with t.Parallel.
+func TestNewFleetDMClientEnvFallback(t *testing.T) {
+	t.Run("empty config and empty env", func(t *testing.T) {
+		t.Setenv("FLEETDM_URL", "")
+		t.Setenv("FLEETDM_API_TOKEN", "")
+		conn := &plugin.Connection{Name: "test", Config: fleetdmConfig{}}
+		_, err := NewFleetDMClient(testCtx(t), conn)
+		if err == nil {
+			t.Fatal("NewFleetDMClient with no config and no env = nil error, want error")
+		}
+		if !strings.Contains(err.Error(), "FLEETDM_URL") {
+			t.Errorf("error = %q, want it to mention FLEETDM_URL", err)
+		}
+	})
+
+	t.Run("env used when config nil", func(t *testing.T) {
+		t.Setenv("FLEETDM_URL", "https://env.example.com")
+		t.Setenv("FLEETDM_API_TOKEN", "env-token")
+		conn := &plugin.Connection{Name: "test", Config: nil}
+		client, err := NewFleetDMClient(testCtx(t), conn)
+		if err != nil {
+			t.Fatalf("NewFleetDMClient from env unexpected error: %v", err)
+		}
+		if client.BaseURL != "https://env.example.com/api/v1/fleet/" {
+			t.Errorf("BaseURL = %q, want %q", client.BaseURL, "https://env.example.com/api/v1/fleet/")
+		}
+		if client.APIToken != "env-token" {
+			t.Errorf("APIToken = %q, want %q", client.APIToken, "env-token")
+		}
+	})
+
+	t.Run("config wins over env", func(t *testing.T) {
+		t.Setenv("FLEETDM_URL", "https://env.example.com")
+		t.Setenv("FLEETDM_API_TOKEN", "env-token")
+		conn := testConnection(ptr("https://spc.example.com"), ptr("spc-token"), nil)
+		client, err := NewFleetDMClient(testCtx(t), conn)
+		if err != nil {
+			t.Fatalf("NewFleetDMClient unexpected error: %v", err)
+		}
+		if client.BaseURL != "https://spc.example.com/api/v1/fleet/" {
+			t.Errorf("BaseURL = %q, want config value to win over env", client.BaseURL)
+		}
+		if client.APIToken != "spc-token" {
+			t.Errorf("APIToken = %q, want config value to win over env", client.APIToken)
+		}
+	})
+}
+
+func TestNewFleetDMClientRequestTimeout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		timeout *int
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "default when unset", timeout: nil, want: 30 * time.Second},
+		{name: "explicit 5 seconds", timeout: ptr(5), want: 5 * time.Second},
+		{name: "zero rejected", timeout: ptr(0), wantErr: true},
+		{name: "negative rejected", timeout: ptr(-1), wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			conn := testConnection(ptr("https://fleet.example.com"), ptr("t"), tc.timeout)
+			client, err := NewFleetDMClient(testCtx(t), conn)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("NewFleetDMClient = nil error, want error for non-positive request_timeout")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewFleetDMClient unexpected error: %v", err)
+			}
+			if client.HTTPClient.Timeout != tc.want {
+				t.Errorf("HTTPClient.Timeout = %v, want %v", client.HTTPClient.Timeout, tc.want)
+			}
+		})
+	}
+}

--- a/fleetdm/version.go
+++ b/fleetdm/version.go
@@ -1,0 +1,5 @@
+package fleetdm
+
+// pluginVersion identifies this build in the User-Agent header sent to the
+// FleetDM API. Bumped as part of the release process.
+var pluginVersion = "dev"


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
go test -race -count=1 ./...  → ok (77 test runs, first tests in the repo)
gofmt / go vet / golangci-lint / gosec / govulncheck → all clean
Live smoke (Fleet v4.86.1 via docker): 15-table sweep passes;
multi-page pagination verified (1,314 activities across 27 pages)
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select count(*) from fleetdm_activity;   -- meta-driven pagination
 1314
> select id from fleetdm_activity limit 5; -- LIMIT now sizes per_page=5
 (5 rows, single API call)
> select * from fleetdm_host_detail where id = 999999;
 (0 rows — was an API error before the ignore-404 config)
```
</details>
