### PR TITLE
ci: stop passing undeclared SECURITY_API_TOKEN to turbot reusable workflows

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,7 +13,5 @@ permissions:
 jobs:
   golangci_lint_workflow:
     uses: turbot/steampipe-workflows/.github/workflows/golangci-lint.yml@210ab7cc3f105a795a389cf30d68c394ee46af5e # main 2026-07-29
-    secrets:
-      SECURITY_API_TOKEN: ${{ secrets.SECURITY_API_TOKEN }}
     with:
       timeout: 20m

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,7 +20,5 @@ jobs:
       issues: write
       pull-requests: write
     uses: turbot/steampipe-workflows/.github/workflows/stale.yml@210ab7cc3f105a795a389cf30d68c394ee46af5e # main 2026-07-29
-    secrets:
-      SECURITY_API_TOKEN: ${{ secrets.SECURITY_API_TOKEN }}
     with:
       dryRun: ${{ github.event.inputs.dryRun }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -13,5 +13,3 @@ jobs:
       contents: read
       issues: write
     uses: turbot/steampipe-workflows/.github/workflows/sync-labels.yml@210ab7cc3f105a795a389cf30d68c394ee46af5e # main 2026-07-29
-    secrets:
-      SECURITY_API_TOKEN: ${{ secrets.SECURITY_API_TOKEN }}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
zizmor .github/workflows/ → no findings
Pinned SHAs re-verified equal to turbot/steampipe-workflows@main HEAD
Proof: this PR's own golangci-lint check must start and pass (startup_failure produced no check at all before)
```
</details>

# Example query results
<details>
  <summary>Results</summary>

(not applicable — CI-only change)
</details>
