### PR TITLE
Add endpoint compat layer for teams→fleets and queries→reports renames

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,14 +228,21 @@ Then, run queries against the available tables.
 **Available Tables:**
 
 * `fleetdm_activity`
+* `fleetdm_app_store_app`
+* `fleetdm_carve`
+* `fleetdm_fleet_maintained_app`
 * `fleetdm_host`
+* `fleetdm_host_detail`
 * `fleetdm_label`
+* `fleetdm_os_version`
 * `fleetdm_pack`
 * `fleetdm_policy`
 * `fleetdm_query`
-* `fleetdm_software`
+* `fleetdm_software_title`
+* `fleetdm_software_version`
 * `fleetdm_team`
 * `fleetdm_user`
+* `fleetdm_version`
 
 **Example Queries:**
 
@@ -275,9 +282,9 @@ WHERE
   id = 24; -- Replace with an actual host ID
 ```
 
-### `fleetdm_software`
+### `fleetdm_software_version`
 
-List the top 10 most installed software:
+List the top 10 most installed software versions:
 ```sql
 SELECT
   name,
@@ -285,13 +292,13 @@ SELECT
   source,
   host_count
 FROM
-  fleetdm_software
+  fleetdm_software_version
 ORDER BY
   host_count DESC
 LIMIT 10;
 ```
 
-Find software with known vulnerabilities (if vulnerability processing is enabled in FleetDM):
+Find software versions with known vulnerabilities (if vulnerability processing is enabled in FleetDM):
 ```sql
 SELECT
   name,
@@ -299,7 +306,7 @@ SELECT
   host_count,
   vulnerabilities
 FROM
-  fleetdm_software
+  fleetdm_software_version
 WHERE
   vulnerable_only = true; -- Uses KeyColumn for API filtering
 ```

--- a/docs/tables/fleetdm_carve.md
+++ b/docs/tables/fleetdm_carve.md
@@ -28,6 +28,8 @@ from
 order by
   id desc
 limit 50;
+```
+
 ```sql+sqlite
 select
   id,
@@ -58,6 +60,8 @@ where
   error is not null
 order by
   created_at desc;
+```
+
 ```sql+sqlite
 select
   id,
@@ -89,6 +93,8 @@ where
   host_id = 7 -- Replace with an actual host ID
 order by
   id desc;
+```
+
 ```sql+sqlite
 select
   id,

--- a/docs/tables/fleetdm_host_detail.md
+++ b/docs/tables/fleetdm_host_detail.md
@@ -25,6 +25,8 @@ from
 where
   h.id = 1
   and p ->> 'response' = 'fail';
+```
+
 ```sql+sqlite
 select
   h.hostname,
@@ -50,6 +52,8 @@ from
   jsonb_array_elements(h.software) as s
 where
   h.id = 1;
+```
+
 ```sql+sqlite
 select
   h.hostname,
@@ -75,6 +79,8 @@ from
   jsonb_array_elements(batteries) as b
 where
   (b ->> 'cycle_count')::int < 50;
+```
+
 ```sql+sqlite
 select
   hostname,
@@ -100,6 +106,8 @@ from
   jsonb_array_elements(h.users) as u
 where
   h.id = 1;
+```
+
 ```sql+sqlite
 select
   h.hostname,
@@ -111,3 +119,4 @@ from
   json_each(h.users) as u
 where
   h.id = 1;
+```

--- a/docs/tables/fleetdm_pack.md
+++ b/docs/tables/fleetdm_pack.md
@@ -5,6 +5,8 @@ description: "Allows users to query FleetDM query packs, providing insights into
 
 # Table: fleetdm_pack - Query FleetDM Query Packs using SQL
 
+> **Deprecation note:** The Packs API has been removed from current FleetDM documentation. This table keeps working against older servers, but on newer ones it may return empty results or a 404 (which the plugin treats as no rows).
+
 FleetDM is an open-source device management platform that helps you manage and secure your devices. Query packs in FleetDM are collections of queries that can be scheduled to run against targeted hosts or labels, enabling automated data collection and monitoring.
 
 ## Table Usage Guide

--- a/docs/tables/fleetdm_query.md
+++ b/docs/tables/fleetdm_query.md
@@ -45,7 +45,6 @@ Using these key columns in your `WHERE` clause pushes the filtering to the Fleet
 | query_text_filter   | `TEXT`      | (Key Column) Search query string to filter saved queries by name or SQL. Use in `WHERE` clause.         |
 | platform_filter     | `TEXT`      | (Key Column) Filter by scheduled platform: `macos`, `windows`, or `linux`. Use in `WHERE` clause.       |
 | merge_inherited     | `BOOLEAN`   | (Key Column) Include global queries when `team_id` is specified (Fleet Premium). Use in `WHERE` clause. |
-| server_url          | `TEXT`      | FleetDM server URL from connection config.                                                              |
 
 ## Examples
 

--- a/docs/tables/fleetdm_software_title.md
+++ b/docs/tables/fleetdm_software_title.md
@@ -41,7 +41,6 @@ The `fleetdm_software_title` table provides aggregated insights into your softwa
 | exploit                       | `BOOLEAN` | (Key Column) Filter for software with CISA-known actively exploited vulnerabilities (Fleet Premium). Use in `WHERE` clause.                        |
 | platform                      | `TEXT`    | (Key Column) Filter installable titles by platform. Options: 'macos', 'darwin', 'windows', 'linux', 'chrome', 'ios', 'ipados'. Requires team_id.   |
 | exclude_fleet_maintained_apps | `BOOLEAN` | (Key Column) Exclude Fleet-maintained apps from the results. Use in `WHERE` clause.                                                                |
-| server_url                    | `TEXT`    | FleetDM server URL from connection config.                                                                                                         |
 
 ## Examples
 

--- a/docs/tables/fleetdm_software_version.md
+++ b/docs/tables/fleetdm_software_version.md
@@ -40,7 +40,6 @@ The `fleetdm_software_version` table provides detailed insights into your softwa
 | min_cvss_score    | `INT`       | (Key Column) Filter for software with vulnerabilities having a CVSS v3.x base score higher than this value (Fleet Premium). Use in `WHERE` clause.               |
 | max_cvss_score    | `INT`       | (Key Column) Filter for software with vulnerabilities having a CVSS v3.x base score lower than this value (Fleet Premium). Use in `WHERE` clause.                |
 | exploit           | `BOOLEAN`   | (Key Column) Filter for software with vulnerabilities that have been actively exploited in the wild — CISA known exploit (Fleet Premium). Use in `WHERE` clause. |
-| server_url        | `TEXT`      | FleetDM server URL from connection config.                                                                                                                       |
 
 ## Examples
 

--- a/docs/tables/fleetdm_version.md
+++ b/docs/tables/fleetdm_version.md
@@ -1,0 +1,80 @@
+---
+title: "Steampipe Table: fleetdm_version - Query FleetDM Server Version using SQL"
+description: "Allows users to query the FleetDM server version and build information, useful for inventory, upgrade planning, and compatibility checks."
+---
+
+# Table: fleetdm_version - Query FleetDM Server Version using SQL
+
+FleetDM is an open-source device management platform that helps you manage and secure your devices. The version endpoint reports the Fleet server's version and build details.
+
+## Table Usage Guide
+
+The `fleetdm_version` table returns a single row with the Fleet server's version and build information. As a system administrator, you can use this table to record which server version each connection talks to, plan upgrades, and confirm compatibility before relying on newer API features.
+
+## Examples
+
+### Get the server version
+
+Check which Fleet version the connection is talking to.
+
+```sql+postgres
+select
+  version,
+  branch,
+  revision
+from
+  fleetdm_version;
+```
+
+```sql+sqlite
+select
+  version,
+  branch,
+  revision
+from
+  fleetdm_version;
+```
+
+### Get full build information
+
+Inspect how and when the server binary was built.
+
+```sql+postgres
+select
+  version,
+  go_version,
+  build_date,
+  build_user
+from
+  fleetdm_version;
+```
+
+```sql+sqlite
+select
+  version,
+  go_version,
+  build_date,
+  build_user
+from
+  fleetdm_version;
+```
+
+### Flag servers older than a minimum version
+
+Compare the reported version against a required minimum (simple string comparison; adjust for your versioning scheme).
+
+```sql+postgres
+select
+  version,
+  version < '4.50.0' as needs_upgrade
+from
+  fleetdm_version;
+```
+
+```sql+sqlite
+select
+  version,
+  version < '4.50.0' as needs_upgrade
+from
+  fleetdm_version;
+```

--- a/fleetdm/endpoint_compat.go
+++ b/fleetdm/endpoint_compat.go
@@ -1,0 +1,182 @@
+package fleetdm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+)
+
+// endpointFamily identifies a group of FleetDM API endpoints that were renamed
+// upstream (teams -> fleets, queries -> reports). Old servers (<= v4.x) only
+// serve the old paths; new servers may drop the old paths entirely, so the
+// plugin resolves which generation a server speaks at query time and caches
+// the answer per connection.
+type endpointFamily string
+
+const (
+	famFleets        endpointFamily = "fleets"         // fleets <- teams
+	famReports       endpointFamily = "reports"        // reports <- queries
+	famFleetPolicies endpointFamily = "fleet_policies" // fleets/%d/policies <- teams/%d/policies
+)
+
+// endpointPaths maps a family to {newPathFormat, oldPathFormat}. The formats
+// may contain fmt verbs filled from GetCompat's pathArgs.
+var endpointPaths = map[endpointFamily][2]string{
+	famFleets:        {"fleets", "teams"},
+	famReports:       {"reports", "queries"},
+	famFleetPolicies: {"fleets/%d/policies", "teams/%d/policies"},
+}
+
+// is404 reports whether err is a *FleetAPIError with a 404 status.
+func is404(err error) bool {
+	var apiErr *FleetAPIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound
+}
+
+// resolveCompat is the pure decision core behind GetCompat, extracted so it
+// can be unit-tested without SDK plumbing.
+//
+// cached is the previously resolved generation for the family (nil if not yet
+// resolved). When cached, exactly one request is made against that generation
+// and its result is returned verbatim — a genuine 404 (e.g. a deleted id) must
+// surface/ignore normally, never flip the generation.
+//
+// When not cached, the NEW path is tried first. Resolution only happens on a
+// definitive signal:
+//   - new path succeeds            -> useNew=true
+//   - new path 404, old succeeds   -> useNew=false
+//   - new path 404, old also errs  -> old error returned, nothing resolved
+//     (could be a genuine 404 on both generations)
+//   - new path non-404 error       -> error returned, nothing resolved
+//     (401/403/5xx say nothing about the generation)
+//
+// The returned useNew is non-nil only when this call resolved the generation.
+func resolveCompat(tryNew, tryOld func() error, cached *bool) (useNew *bool, err error) {
+	if cached != nil {
+		if *cached {
+			return nil, tryNew()
+		}
+		return nil, tryOld()
+	}
+
+	if err := tryNew(); err != nil {
+		if !is404(err) {
+			return nil, err
+		}
+		if oldErr := tryOld(); oldErr != nil {
+			return nil, oldErr
+		}
+		resolved := false
+		return &resolved, nil
+	}
+	resolved := true
+	return &resolved, nil
+}
+
+// GetCompat performs a GET against a renamed endpoint family, transparently
+// falling back from the new path to the old one on 404 and caching the
+// resolved generation in the connection cache (which is already scoped
+// per-connection, so the key needs no connection name).
+func (c *FleetDMClient) GetCompat(ctx context.Context, d *plugin.QueryData, fam endpointFamily, pathArgs []any, params url.Values, target any) error {
+	paths, ok := endpointPaths[fam]
+	if !ok {
+		return fmt.Errorf("endpoint_compat: unknown endpoint family %q", fam)
+	}
+	newPath, oldPath := paths[0], paths[1]
+	if len(pathArgs) > 0 {
+		newPath = fmt.Sprintf(newPath, pathArgs...)
+		oldPath = fmt.Sprintf(oldPath, pathArgs...)
+	}
+
+	cacheKey := "endpoint_family/" + string(fam)
+	var cached *bool
+	if v, ok := d.ConnectionCache.Get(ctx, cacheKey); ok {
+		if b, ok := v.(bool); ok {
+			cached = &b
+		}
+	}
+
+	useNew, err := resolveCompat(
+		func() error { return c.Get(ctx, newPath, params, target) },
+		func() error { return c.Get(ctx, oldPath, params, target) },
+		cached,
+	)
+	if useNew != nil {
+		plugin.Logger(ctx).Info("endpoint_compat", "family", fam, "use_new", *useNew)
+		if cerr := d.ConnectionCache.Set(ctx, cacheKey, *useNew); cerr != nil {
+			plugin.Logger(ctx).Warn("endpoint_compat", "connection_cache_set_error", cerr, "family", fam)
+		}
+	}
+	return err
+}
+
+// coalesceSlice returns newer when it has elements, otherwise older. Used to
+// read response envelopes that renamed their key (e.g. "fleets" vs "teams")
+// without caring which generation answered.
+func coalesceSlice[T any](newer, older []T) []T {
+	if len(newer) > 0 {
+		return newer
+	}
+	return older
+}
+
+// addFleetIDParam sets BOTH the new "fleet_id" and the old "team_id" query
+// parameters to id. Servers of either generation ignore the unknown one; the
+// helper centralizes that policy so table code stays generation-agnostic.
+func addFleetIDParam(params url.Values, id string) {
+	params.Set("fleet_id", id)
+	params.Set("team_id", id)
+}
+
+// requireExposeSecrets gates tables that return live secret material behind
+// the expose_secrets connection config flag.
+func requireExposeSecrets(d *plugin.QueryData) error {
+	config := GetConfig(d.Connection)
+	if config.ExposeSecrets != nil && *config.ExposeSecrets {
+		return nil
+	}
+	return errors.New("this table returns live secrets; set expose_secrets = true in the fleetdm connection config to query it")
+}
+
+// isPremiumError classifies err as a Fleet Premium licensing failure: a 402,
+// or a 400/403 whose body mentions a license/premium requirement.
+func isPremiumError(err error) bool {
+	var apiErr *FleetAPIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	switch apiErr.StatusCode {
+	case http.StatusPaymentRequired:
+		return true
+	case http.StatusBadRequest, http.StatusForbidden:
+		snippet := strings.ToLower(apiErr.Snippet)
+		return strings.Contains(snippet, "license") || strings.Contains(snippet, "premium")
+	}
+	return false
+}
+
+// handlePremiumError returns true when err is a Fleet Premium licensing
+// failure that should be swallowed (treat as zero rows) instead of failing
+// the query. It logs one Warn per connection+table, deduped via the
+// connection cache.
+func handlePremiumError(ctx context.Context, d *plugin.QueryData, table string, err error) bool {
+	if !isPremiumError(err) {
+		return false
+	}
+	cacheKey := "premium_warned/" + table
+	if d != nil && d.ConnectionCache != nil {
+		if _, warned := d.ConnectionCache.Get(ctx, cacheKey); warned {
+			return true
+		}
+		if cerr := d.ConnectionCache.Set(ctx, cacheKey, true); cerr != nil {
+			plugin.Logger(ctx).Warn("handlePremiumError", "connection_cache_set_error", cerr, "table", table)
+		}
+	}
+	plugin.Logger(ctx).Warn("handlePremiumError", "table", table, "premium_feature_unavailable", err.Error())
+	return true
+}

--- a/fleetdm/endpoint_compat_test.go
+++ b/fleetdm/endpoint_compat_test.go
@@ -1,0 +1,297 @@
+package fleetdm
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+)
+
+// apiErr builds a *FleetAPIError with the given status code and snippet.
+func apiErr(status int, snippet string) *FleetAPIError {
+	return &FleetAPIError{
+		StatusCode: status,
+		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		URL:        "https://fleet.example.com/api/v1/fleet/test",
+		Snippet:    snippet,
+	}
+}
+
+// countingFetch returns a fetch func that returns err and counts calls.
+func countingFetch(err error, calls *int) func() error {
+	return func() error {
+		*calls++
+		return err
+	}
+}
+
+func TestResolveCompatUncached(t *testing.T) {
+	t.Parallel()
+
+	notFound := apiErr(http.StatusNotFound, "not found")
+	unauthorized := apiErr(http.StatusUnauthorized, "authentication required")
+
+	tests := []struct {
+		name         string
+		newErr       error
+		oldErr       error
+		wantUseNew   *bool // nil means "not resolved"
+		wantErr      error
+		wantNewCalls int
+		wantOldCalls int
+	}{
+		{
+			name:         "new succeeds resolves useNew true",
+			newErr:       nil,
+			wantUseNew:   ptr(true),
+			wantNewCalls: 1,
+			wantOldCalls: 0,
+		},
+		{
+			name:         "new 404 old succeeds resolves useNew false",
+			newErr:       notFound,
+			oldErr:       nil,
+			wantUseNew:   ptr(false),
+			wantNewCalls: 1,
+			wantOldCalls: 1,
+		},
+		{
+			name:         "new 404 old 404 returns old error unresolved",
+			newErr:       notFound,
+			oldErr:       notFound,
+			wantErr:      notFound,
+			wantNewCalls: 1,
+			wantOldCalls: 1,
+		},
+		{
+			name:         "new 401 returns error unresolved without fallback",
+			newErr:       unauthorized,
+			wantErr:      unauthorized,
+			wantNewCalls: 1,
+			wantOldCalls: 0,
+		},
+		{
+			name:         "new 404 old 500 returns old error unresolved",
+			newErr:       notFound,
+			oldErr:       apiErr(http.StatusInternalServerError, "boom"),
+			wantErr:      apiErr(http.StatusInternalServerError, "boom"),
+			wantNewCalls: 1,
+			wantOldCalls: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var newCalls, oldCalls int
+			useNew, err := resolveCompat(countingFetch(tc.newErr, &newCalls), countingFetch(tc.oldErr, &oldCalls), nil)
+
+			if tc.wantErr == nil && err != nil {
+				t.Fatalf("resolveCompat unexpected error: %v", err)
+			}
+			if tc.wantErr != nil && (err == nil || err.Error() != tc.wantErr.Error()) {
+				t.Fatalf("resolveCompat error = %v, want %v", err, tc.wantErr)
+			}
+			if (useNew == nil) != (tc.wantUseNew == nil) {
+				t.Fatalf("resolveCompat useNew = %v, want %v", useNew, tc.wantUseNew)
+			}
+			if useNew != nil && *useNew != *tc.wantUseNew {
+				t.Fatalf("resolveCompat *useNew = %v, want %v", *useNew, *tc.wantUseNew)
+			}
+			if newCalls != tc.wantNewCalls || oldCalls != tc.wantOldCalls {
+				t.Fatalf("resolveCompat calls = new:%d old:%d, want new:%d old:%d", newCalls, oldCalls, tc.wantNewCalls, tc.wantOldCalls)
+			}
+		})
+	}
+}
+
+func TestResolveCompatCached(t *testing.T) {
+	t.Parallel()
+
+	notFound := apiErr(http.StatusNotFound, "not found")
+
+	tests := []struct {
+		name         string
+		cached       bool
+		newErr       error
+		oldErr       error
+		wantErr      error
+		wantNewCalls int
+		wantOldCalls int
+	}{
+		{
+			name:         "cached new calls only new path",
+			cached:       true,
+			wantNewCalls: 1,
+			wantOldCalls: 0,
+		},
+		{
+			name:         "cached old calls only old path",
+			cached:       false,
+			wantNewCalls: 0,
+			wantOldCalls: 1,
+		},
+		{
+			name:         "cached new does not flip on genuine 404",
+			cached:       true,
+			newErr:       notFound,
+			wantErr:      notFound,
+			wantNewCalls: 1,
+			wantOldCalls: 0,
+		},
+		{
+			name:         "cached old does not flip on genuine 404",
+			cached:       false,
+			oldErr:       notFound,
+			wantErr:      notFound,
+			wantNewCalls: 0,
+			wantOldCalls: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var newCalls, oldCalls int
+			useNew, err := resolveCompat(countingFetch(tc.newErr, &newCalls), countingFetch(tc.oldErr, &oldCalls), ptr(tc.cached))
+
+			if useNew != nil {
+				t.Fatalf("resolveCompat with cached generation resolved again: useNew = %v", *useNew)
+			}
+			if tc.wantErr == nil && err != nil {
+				t.Fatalf("resolveCompat unexpected error: %v", err)
+			}
+			if tc.wantErr != nil && (err == nil || err.Error() != tc.wantErr.Error()) {
+				t.Fatalf("resolveCompat error = %v, want %v", err, tc.wantErr)
+			}
+			if newCalls != tc.wantNewCalls || oldCalls != tc.wantOldCalls {
+				t.Fatalf("resolveCompat calls = new:%d old:%d, want new:%d old:%d", newCalls, oldCalls, tc.wantNewCalls, tc.wantOldCalls)
+			}
+		})
+	}
+}
+
+func TestCoalesceSlice(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		newer []string
+		older []string
+		want  []string
+	}{
+		{name: "both empty", newer: nil, older: nil, want: nil},
+		{name: "newer wins", newer: []string{"a"}, older: []string{"b"}, want: []string{"a"}},
+		{name: "older fallback", newer: nil, older: []string{"b"}, want: []string{"b"}},
+		{name: "empty non-nil newer falls back", newer: []string{}, older: []string{"b"}, want: []string{"b"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := coalesceSlice(tc.newer, tc.older)
+			if len(got) != len(tc.want) {
+				t.Fatalf("coalesceSlice(%v, %v) = %v, want %v", tc.newer, tc.older, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("coalesceSlice(%v, %v) = %v, want %v", tc.newer, tc.older, got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+func TestAddFleetIDParam(t *testing.T) {
+	t.Parallel()
+
+	params := url.Values{}
+	addFleetIDParam(params, "7")
+	if got := params["fleet_id"]; len(got) != 1 || got[0] != "7" {
+		t.Errorf("fleet_id = %v, want [7]", got)
+	}
+	if got := params["team_id"]; len(got) != 1 || got[0] != "7" {
+		t.Errorf("team_id = %v, want [7]", got)
+	}
+}
+
+func TestIsPremiumError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "402 payment required", err: apiErr(http.StatusPaymentRequired, ""), want: true},
+		{name: "403 with license snippet", err: apiErr(http.StatusForbidden, "requires a Fleet license"), want: true},
+		{name: "403 with Premium snippet case-insensitive", err: apiErr(http.StatusForbidden, "Requires Fleet PREMIUM"), want: true},
+		{name: "400 with premium snippet", err: apiErr(http.StatusBadRequest, "premium feature"), want: true},
+		{name: "403 without license snippet", err: apiErr(http.StatusForbidden, "forbidden"), want: false},
+		{name: "500 with license snippet", err: apiErr(http.StatusInternalServerError, "license"), want: false},
+		{name: "wrapped 402", err: fmt.Errorf("outer: %w", apiErr(http.StatusPaymentRequired, "")), want: true},
+		{name: "plain error", err: errors.New("license premium"), want: false},
+		{name: "nil error", err: nil, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isPremiumError(tc.err); got != tc.want {
+				t.Errorf("isPremiumError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHandlePremiumError(t *testing.T) {
+	t.Parallel()
+
+	ctx := testCtx(t)
+	// nil QueryData exercises the nil-safe dedupe path.
+	if !handlePremiumError(ctx, nil, "fleetdm_test", apiErr(http.StatusPaymentRequired, "")) {
+		t.Error("handlePremiumError(402) = false, want true")
+	}
+	if handlePremiumError(ctx, nil, "fleetdm_test", apiErr(http.StatusInternalServerError, "boom")) {
+		t.Error("handlePremiumError(500) = true, want false")
+	}
+	if handlePremiumError(ctx, nil, "fleetdm_test", nil) {
+		t.Error("handlePremiumError(nil) = true, want false")
+	}
+}
+
+func TestRequireExposeSecrets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		expose  *bool
+		wantErr bool
+	}{
+		{name: "unset denies", expose: nil, wantErr: true},
+		{name: "false denies", expose: ptr(false), wantErr: true},
+		{name: "true allows", expose: ptr(true), wantErr: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			d := &plugin.QueryData{
+				Connection: &plugin.Connection{
+					Name:   "test",
+					Config: fleetdmConfig{ExposeSecrets: tc.expose},
+				},
+			}
+			err := requireExposeSecrets(d)
+			if tc.wantErr && err == nil {
+				t.Fatal("requireExposeSecrets = nil error, want error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("requireExposeSecrets unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/fleetdm/plugin.go
+++ b/fleetdm/plugin.go
@@ -47,6 +47,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"fleetdm_software_version":     tableFleetdmSoftwareVersion(ctx),
 			"fleetdm_team":                 tableFleetdmTeam(ctx),
 			"fleetdm_user":                 tableFleetdmUser(ctx),
+			"fleetdm_version":              tableFleetdmVersion(ctx),
 		},
 	}
 	return p

--- a/fleetdm/table_fleetdm_app_store_app.go
+++ b/fleetdm/table_fleetdm_app_store_app.go
@@ -109,15 +109,16 @@ func listAppStoreApps(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 			params.Add("per_page", strconv.Itoa(perPage))
 
 			var teamsResponse ListTeamsResponse
-			if err := client.Get(ctx, "teams", params, &teamsResponse); err != nil {
+			if err := client.GetCompat(ctx, d, famFleets, nil, params, &teamsResponse); err != nil {
 				plugin.Logger(ctx).Error("fleetdm_app_store_app.listAppStoreApps", "teams_api_error", err, "page", page)
 				return nil, err
 			}
 
-			if len(teamsResponse.Teams) == 0 {
+			teams := coalesceSlice(teamsResponse.Fleets, teamsResponse.Teams)
+			if len(teams) == 0 {
 				break
 			}
-			for _, team := range teamsResponse.Teams {
+			for _, team := range teams {
 				teamsToQuery = append(teamsToQuery, teamInfo{ID: team.ID, Name: team.Name})
 			}
 		}
@@ -128,7 +129,7 @@ func listAppStoreApps(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 	// For each team, query the app store apps endpoint.
 	for _, team := range teamsToQuery {
 		params := url.Values{}
-		params.Add("team_id", strconv.FormatUint(uint64(team.ID), 10))
+		addFleetIDParam(params, strconv.FormatUint(uint64(team.ID), 10))
 
 		var response ListAppStoreAppsResponse
 		if err := client.Get(ctx, "software/app_store_apps", params, &response); err != nil {

--- a/fleetdm/table_fleetdm_fleet_maintained_app.go
+++ b/fleetdm/table_fleetdm_fleet_maintained_app.go
@@ -68,7 +68,7 @@ func listFleetMaintainedApps(ctx context.Context, d *plugin.QueryData, h *plugin
 		params.Add("per_page", strconv.Itoa(perPage))
 
 		if d.EqualsQuals["team_id"] != nil {
-			params.Add("team_id", strconv.FormatInt(d.EqualsQuals["team_id"].GetInt64Value(), 10))
+			addFleetIDParam(params, strconv.FormatInt(d.EqualsQuals["team_id"].GetInt64Value(), 10))
 		}
 
 		var response ListFleetMaintainedAppsResponse

--- a/fleetdm/table_fleetdm_host.go
+++ b/fleetdm/table_fleetdm_host.go
@@ -313,7 +313,7 @@ func listHosts(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) 
 			params.Add("query", d.EqualsQuals["query"].GetStringValue())
 		}
 		if d.EqualsQuals["team_id"] != nil {
-			params.Add("team_id", strconv.FormatInt(d.EqualsQuals["team_id"].GetInt64Value(), 10))
+			addFleetIDParam(params, strconv.FormatInt(d.EqualsQuals["team_id"].GetInt64Value(), 10))
 		}
 		if d.EqualsQuals["status"] != nil {
 			params.Add("status", d.EqualsQuals["status"].GetStringValue())

--- a/fleetdm/table_fleetdm_host_detail.go
+++ b/fleetdm/table_fleetdm_host_detail.go
@@ -287,7 +287,7 @@ func listHostsForDetails(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 		params.Add("order_direction", "asc")
 
 		if d.EqualsQuals["team_id"] != nil {
-			params.Add("team_id", strconv.FormatInt(d.EqualsQuals["team_id"].GetInt64Value(), 10))
+			addFleetIDParam(params, strconv.FormatInt(d.EqualsQuals["team_id"].GetInt64Value(), 10))
 		}
 		if d.EqualsQuals["status"] != nil {
 			params.Add("status", d.EqualsQuals["status"].GetStringValue())

--- a/fleetdm/table_fleetdm_label.go
+++ b/fleetdm/table_fleetdm_label.go
@@ -84,7 +84,7 @@ func listLabels(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData)
 		params.Add("per_page", strconv.Itoa(perPage))
 
 		if d.EqualsQuals["team_id"] != nil {
-			params.Add("team_id", d.EqualsQuals["team_id"].GetStringValue())
+			addFleetIDParam(params, d.EqualsQuals["team_id"].GetStringValue())
 		}
 
 		var response ListLabelsResponse

--- a/fleetdm/table_fleetdm_os_version.go
+++ b/fleetdm/table_fleetdm_os_version.go
@@ -94,7 +94,7 @@ func listOSVersions(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateD
 		params.Add("order_direction", "desc")
 
 		if d.EqualsQuals["team_id"] != nil {
-			params.Add("team_id", strconv.FormatInt(d.EqualsQuals["team_id"].GetInt64Value(), 10))
+			addFleetIDParam(params, strconv.FormatInt(d.EqualsQuals["team_id"].GetInt64Value(), 10))
 		}
 		if d.EqualsQuals["platform"] != nil {
 			params.Add("platform", d.EqualsQuals["platform"].GetStringValue())

--- a/fleetdm/table_fleetdm_policy.go
+++ b/fleetdm/table_fleetdm_policy.go
@@ -2,6 +2,7 @@ package fleetdm
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strconv"
 
@@ -52,10 +53,12 @@ func tableFleetdmPolicy(ctx context.Context) *plugin.Table {
 			Hydrate: listPolicies,
 			// The API uses two different endpoints:
 			// - Without team_id: GET /global/policies (supports page, per_page only)
-			// - With team_id:    GET /teams/:id/policies (supports query, merge_inherited, page, per_page)
+			// - With team_id:    GET /teams/:id/policies, renamed upstream to
+			//   /fleets/:id/policies (supports query, merge_inherited, page, per_page)
 			KeyColumns: []*plugin.KeyColumn{
 				{Name: "filter_search_query", Require: plugin.Optional}, // Maps to API 'query' param (team policies only)
 				{Name: "team_id", Require: plugin.Optional},             // Switches to team policies endpoint
+				{Name: "fleet_id", Require: plugin.Optional},            // Alias of team_id (newer Fleet naming)
 				{Name: "merge_inherited", Require: plugin.Optional},     // Include global policies with team results (Fleet Premium)
 			},
 		},
@@ -79,6 +82,7 @@ func tableFleetdmPolicy(ctx context.Context) *plugin.Table {
 
 			// Key column for filtering via API 'query' parameter
 			{Name: "filter_search_query", Type: proto.ColumnType_STRING, Transform: transform.FromQual("filter_search_query"), Description: "Search query string to filter policies by name or query text. Only works when team_id is specified. Set in WHERE clause."},
+			{Name: "fleet_id", Type: proto.ColumnType_INT, Transform: transform.FromQual("fleet_id"), Description: "Alias of team_id using the newer Fleet naming (teams were renamed to fleets). Set in WHERE clause to list a specific fleet's policies."},
 			{Name: "merge_inherited", Type: proto.ColumnType_BOOL, Transform: transform.FromQual("merge_inherited"), Description: "If true, includes global policies in team policy results (Fleet Premium). Requires team_id. Set in WHERE clause."},
 		},
 	}
@@ -91,12 +95,22 @@ func listPolicies(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDat
 		return nil, err
 	}
 
-	// Determine endpoint: global/policies or teams/:id/policies
-	endpoint := "global/policies"
+	// Resolve the team/fleet scope: team_id and its newer alias fleet_id are
+	// interchangeable, but conflicting values are a user error.
+	var teamID *int64
 	if d.EqualsQuals["team_id"] != nil {
-		teamID := strconv.FormatInt(d.EqualsQuals["team_id"].GetInt64Value(), 10)
-		endpoint = "teams/" + teamID + "/policies"
-		plugin.Logger(ctx).Debug("fleetdm_policy.listPolicies", "using_team_endpoint", endpoint)
+		v := d.EqualsQuals["team_id"].GetInt64Value()
+		teamID = &v
+	}
+	if d.EqualsQuals["fleet_id"] != nil {
+		v := d.EqualsQuals["fleet_id"].GetInt64Value()
+		if teamID != nil && *teamID != v {
+			return nil, fmt.Errorf("team_id (%d) and fleet_id (%d) are aliases and must match when both are set", *teamID, v)
+		}
+		teamID = &v
+	}
+	if teamID != nil {
+		plugin.Logger(ctx).Debug("fleetdm_policy.listPolicies", "using_team_endpoint_for_id", *teamID)
 	}
 
 	err = paginatedList(ctx, d, 100, func(ctx context.Context, page, perPage int) ([]Policy, *ListMeta, error) {
@@ -105,7 +119,7 @@ func listPolicies(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDat
 		params.Add("per_page", strconv.Itoa(perPage))
 
 		// query and merge_inherited are only supported on the team policies endpoint
-		if d.EqualsQuals["team_id"] != nil {
+		if teamID != nil {
 			if d.EqualsQuals["filter_search_query"] != nil {
 				params.Add("query", d.EqualsQuals["filter_search_query"].GetStringValue())
 			}
@@ -115,9 +129,17 @@ func listPolicies(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDat
 		}
 
 		var response ListPoliciesResponse
-		if err := client.Get(ctx, endpoint, params, &response); err != nil {
-			plugin.Logger(ctx).Error("fleetdm_policy.listPolicies", "api_error", err, "page", page, "params", params.Encode(), "endpoint", endpoint)
-			return nil, nil, err
+		var getErr error
+		if teamID != nil {
+			// Team-scoped: teams/:id/policies, renamed to fleets/:id/policies.
+			getErr = client.GetCompat(ctx, d, famFleetPolicies, []any{*teamID}, params, &response)
+		} else {
+			// The global endpoint was not renamed.
+			getErr = client.Get(ctx, "global/policies", params, &response)
+		}
+		if getErr != nil {
+			plugin.Logger(ctx).Error("fleetdm_policy.listPolicies", "api_error", getErr, "page", page, "params", params.Encode())
+			return nil, nil, getErr
 		}
 		// The policies endpoints do not document a meta object for pagination.
 		return response.Policies, nil, nil

--- a/fleetdm/table_fleetdm_query.go
+++ b/fleetdm/table_fleetdm_query.go
@@ -29,9 +29,10 @@ type QuerySaved struct {
 	Interval           *uint           `json:"interval"` // For scheduled queries, in seconds
 	Platform           *string         `json:"platform"` // Comma-separated list or empty for all
 	MinOsqueryVersion  *string         `json:"min_osquery_version"`
-	Logging            *string         `json:"logging"` // "snapshot", "differential", "differential_ignore_removals"
-	Stats              json.RawMessage `json:"stats"`   // Performance statistics, complex object
-	Packs              []QueryPack     `json:"packs"`   // Packs this query belongs to (available on GET /queries/{id})
+	Logging            *string         `json:"logging"`            // "snapshot", "differential", "differential_ignore_removals"
+	Stats              json.RawMessage `json:"stats"`              // Performance statistics, complex object
+	Packs              []QueryPack     `json:"packs"`              // Packs this query belongs to (available on GET /queries/{id})
+	LabelsIncludeAny   interface{}     `json:"labels_include_any"` // Labels targeting the query (newer Fleet only)
 }
 
 // QueryPack minimal info for a pack a query belongs to.
@@ -41,13 +42,14 @@ type QueryPack struct {
 	Type string `json:"type"` // e.g. "global", "team"
 }
 
-// ListQueriesResponse is the structure for the list queries API response.
-// `GET /api/v1/fleet/queries` returns `{"queries": [...]}`
+// ListQueriesResponse is the structure for the list queries/reports API
+// response. Old servers respond with { "queries": [...] }; servers past the
+// queries->reports rename respond with { "reports": [...] }. Both keys are
+// declared so either generation unmarshals; use coalesceSlice(Reports,
+// Queries) to read the result.
 type ListQueriesResponse struct {
 	Queries []QuerySaved `json:"queries"`
-	// Meta  struct { // If pagination meta is introduced
-	// 	HasNextResults bool `json:"has_next_results"`
-	// } `json:"meta"`
+	Reports []QuerySaved `json:"reports"`
 }
 
 // GetQueryResponse is the structure for the get query API response.
@@ -86,6 +88,7 @@ func tableFleetdmQuery(ctx context.Context) *plugin.Table {
 			{Name: "logging_type", Type: proto.ColumnType_STRING, Transform: transform.FromField("Logging"), Description: "Type of logging for query results (e.g., snapshot, differential)."},
 			{Name: "stats", Type: proto.ColumnType_JSON, Description: "Performance statistics for the query execution."},
 			{Name: "packs", Type: proto.ColumnType_JSON, Description: "Packs this query belongs to (details available on GET)."},
+			{Name: "labels_include_any", Type: proto.ColumnType_JSON, Description: "Labels targeting the query; the query only runs on hosts with at least one of these labels (newer Fleet only)."},
 			{Name: "created_at", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("CreatedAt").Transform(flexibleTimeTransform), Description: "Timestamp when the query was created."},
 			{Name: "updated_at", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("UpdatedAt").Transform(flexibleTimeTransform), Description: "Timestamp when the query was last updated."},
 
@@ -113,7 +116,7 @@ func listQueries(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData
 			params.Add("query", d.EqualsQuals["query_text_filter"].GetStringValue())
 		}
 		if d.EqualsQuals["team_id"] != nil {
-			params.Add("team_id", strconv.FormatInt(d.EqualsQuals["team_id"].GetInt64Value(), 10))
+			addFleetIDParam(params, strconv.FormatInt(d.EqualsQuals["team_id"].GetInt64Value(), 10))
 		}
 		if d.EqualsQuals["platform_filter"] != nil {
 			params.Add("platform", d.EqualsQuals["platform_filter"].GetStringValue())
@@ -124,14 +127,14 @@ func listQueries(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData
 		// TODO: Support order_key and order_direction via Quals
 
 		var response ListQueriesResponse
-		if err := client.Get(ctx, "queries", params, &response); err != nil {
+		if err := client.GetCompat(ctx, d, famReports, nil, params, &response); err != nil {
 			plugin.Logger(ctx).Error("fleetdm_query.listQueries", "api_error", err, "page", page, "params", params.Encode())
 			return nil, nil, err
 		}
-		// The /queries endpoint does not document a meta object for pagination.
-		// 'packs' is only populated by GET /api/v1/fleet/queries/{id}, so it is
-		// nil/empty for list rows.
-		return response.Queries, nil, nil
+		// Neither the /queries nor the /reports endpoint documents a meta
+		// object for pagination. 'packs' is only populated by the get-by-id
+		// endpoint, so it is nil/empty for list rows.
+		return coalesceSlice(response.Reports, response.Queries), nil, nil
 	})
 	if err != nil {
 		return nil, err

--- a/fleetdm/table_fleetdm_software_title.go
+++ b/fleetdm/table_fleetdm_software_title.go
@@ -118,7 +118,7 @@ func listSoftwareTitles(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 			params.Add("vulnerable", strconv.FormatBool(d.EqualsQuals["vulnerable_only"].GetBoolValue()))
 		}
 		if d.EqualsQuals["team_id"] != nil {
-			params.Add("team_id", strconv.FormatInt(d.EqualsQuals["team_id"].GetInt64Value(), 10))
+			addFleetIDParam(params, strconv.FormatInt(d.EqualsQuals["team_id"].GetInt64Value(), 10))
 		}
 		if d.EqualsQuals["available_for_install"] != nil {
 			params.Add("available_for_install", strconv.FormatBool(d.EqualsQuals["available_for_install"].GetBoolValue()))

--- a/fleetdm/table_fleetdm_software_version.go
+++ b/fleetdm/table_fleetdm_software_version.go
@@ -151,7 +151,7 @@ func listSoftwareVersions(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 			params.Add("vulnerable", strconv.FormatBool(d.EqualsQuals["vulnerable_only"].GetBoolValue()))
 		}
 		if d.EqualsQuals["team_id"] != nil {
-			params.Add("team_id", strconv.FormatInt(d.EqualsQuals["team_id"].GetInt64Value(), 10))
+			addFleetIDParam(params, strconv.FormatInt(d.EqualsQuals["team_id"].GetInt64Value(), 10))
 		}
 		if d.EqualsQuals["query"] != nil {
 			params.Add("query", d.EqualsQuals["query"].GetStringValue())

--- a/fleetdm/table_fleetdm_team.go
+++ b/fleetdm/table_fleetdm_team.go
@@ -47,16 +47,13 @@ type TeamUser struct {
 	Role       string  `json:"role"`        // User's role within this specific team
 }
 
-// ListTeamsResponse is the structure for the list teams API response.
-// The API `GET /api/v1/fleet/teams` returns an array of teams directly.
-// For consistency, we'll use a wrapper, but the actual API might just be `[]Team`.
-// Update: The API doc for "List teams" (https://fleetdm.com/docs/rest-api/rest-api#list-all-teams)
-// shows a response like: { "teams": [ { ...team_object... } ] }
+// ListTeamsResponse is the structure for the list teams/fleets API response.
+// Old servers respond with { "teams": [...] }; servers past the teams->fleets
+// rename respond with { "fleets": [...] }. Both keys are declared so either
+// generation unmarshals; use coalesceSlice(Fleets, Teams) to read the result.
 type ListTeamsResponse struct {
-	Teams []Team `json:"teams"`
-	// Meta  struct { // If pagination meta is introduced for teams
-	// 	HasNextResults bool `json:"has_next_results"`
-	// } `json:"meta"`
+	Teams  []Team `json:"teams"`
+	Fleets []Team `json:"fleets"`
 }
 
 func tableFleetdmTeam(ctx context.Context) *plugin.Table {
@@ -125,14 +122,14 @@ func listTeams(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) 
 		}
 
 		var response ListTeamsResponse
-		if err := client.Get(ctx, "teams", params, &response); err != nil {
+		if err := client.GetCompat(ctx, d, famFleets, nil, params, &response); err != nil {
 			plugin.Logger(ctx).Error("fleetdm_team.listTeams", "api_error", err, "page", page)
 			return nil, nil, err
 		}
-		// The /teams endpoint does not document a meta object for pagination.
-		// The list endpoint provides top-level team info only; `users` and
-		// `secrets` are populated by the "Get team" endpoint.
-		return response.Teams, nil, nil
+		// Neither the /teams nor the /fleets endpoint documents a meta object
+		// for pagination. The list endpoint provides top-level team info only;
+		// `users` and `secrets` are populated by the "Get team" endpoint.
+		return coalesceSlice(response.Fleets, response.Teams), nil, nil
 	})
 	if err != nil {
 		return nil, err

--- a/fleetdm/table_fleetdm_user.go
+++ b/fleetdm/table_fleetdm_user.go
@@ -87,7 +87,7 @@ func listUsers(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) 
 			params.Add("query", d.EqualsQuals["query"].GetStringValue())
 		}
 		if d.EqualsQuals["team_id"] != nil {
-			params.Add("team_id", strconv.FormatInt(d.EqualsQuals["team_id"].GetInt64Value(), 10))
+			addFleetIDParam(params, strconv.FormatInt(d.EqualsQuals["team_id"].GetInt64Value(), 10))
 		}
 
 		var usersResponse ListUsersResponse

--- a/fleetdm/table_fleetdm_version.go
+++ b/fleetdm/table_fleetdm_version.go
@@ -1,0 +1,59 @@
+package fleetdm
+
+import (
+	"context"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+)
+
+// VersionInfo represents the FleetDM server version and build information.
+// Refer to: GET /api/v1/fleet/version
+type VersionInfo struct {
+	Version   string `json:"version"`
+	Branch    string `json:"branch"`
+	Revision  string `json:"revision"`
+	GoVersion string `json:"go_version"`
+	// BuildDate is kept as a string: the API returns a non-RFC3339 date
+	// (e.g. "2021-03-27"), so it is not parsed into a timestamp.
+	BuildDate string `json:"build_date"`
+	BuildUser string `json:"build_user"`
+}
+
+func tableFleetdmVersion(ctx context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "fleetdm_version",
+		Description: "FleetDM server version and build information.",
+		List: &plugin.ListConfig{
+			Hydrate: listVersion,
+		},
+		Columns: []*plugin.Column{
+			{Name: "version", Type: proto.ColumnType_STRING, Description: "Version of the Fleet server."},
+			{Name: "branch", Type: proto.ColumnType_STRING, Description: "Git branch the Fleet server was built from."},
+			{Name: "revision", Type: proto.ColumnType_STRING, Description: "Git commit revision the Fleet server was built from."},
+			{Name: "go_version", Type: proto.ColumnType_STRING, Description: "Go version the Fleet server was built with."},
+			{Name: "build_date", Type: proto.ColumnType_STRING, Description: "Date the Fleet server was built (as reported by the API, not necessarily RFC3339)."},
+			{Name: "build_user", Type: proto.ColumnType_STRING, Description: "User who built the Fleet server."},
+		},
+	}
+}
+
+// listVersion streams the single version row. GET /version has no pagination
+// and no parameters; the response body is the version object itself (no
+// envelope).
+func listVersion(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	client, err := getClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("fleetdm_version.listVersion", "connection_error", err)
+		return nil, err
+	}
+
+	var version VersionInfo
+	if err := client.Get(ctx, "version", nil, &version); err != nil {
+		plugin.Logger(ctx).Error("fleetdm_version.listVersion", "api_error", err)
+		return nil, err
+	}
+
+	d.StreamListItem(ctx, version)
+	return nil, nil
+}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
go test -race -count=1 ./... → ok (compat resolution, premium-error classification, helpers)
gofmt / go vet / golangci-lint / build → all clean
Live (Fleet 4.90.0, serves both endpoint generations): full table sweep passes,
compat resolves new-path-first with zero 404 fallbacks; pre-rename fallback
direction covered by unit tests on the extracted resolveCompat core
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select version from fleetdm_version;
 4.90.0
> select count(*) from fleetdm_team;      -- served by GET /fleets on 4.90
 5
> select count(*) from fleetdm_policy where fleet_id = 1;  -- new alias qual
 0   (same result as team_id = 1)
```
</details>
